### PR TITLE
feat: implement 0x1b and 0x1c (shl and shr)

### DIFF
--- a/docs/supported_opcodes.md
+++ b/docs/supported_opcodes.md
@@ -33,8 +33,8 @@ This document describes the opcodes supported by Kakarot.
 | 0x18         | XOR         | Bitwise XOR operation           |             |
 | 0x19         | NOT         | Bitwise NOT operation           |             |
 | 0x1a         | BYTE        | Retrieve single byte from word  |             |
-| 0x1b         | SHL         | Shift left                      |             |
-| 0x1c         | SHR         | Logical shift right             |             |
+| 0x1b         | SHL         | Shift left                      | ✅          |
+| 0x1c         | SHR         | Logical shift right             | ✅          |
 | 0x1d         | SAR         | Arithmetic shift right          |             |
 
 ## SHA3

--- a/src/kakarot/instructions.cairo
+++ b/src/kakarot/instructions.cairo
@@ -197,6 +197,10 @@ namespace EVMInstructions {
         add_instruction(instructions, 0x14, ComparisonOperations.exec_eq);
         // 0x15 - ISZERO
         add_instruction(instructions, 0x15, ComparisonOperations.exec_iszero);
+        // 0x1B - SHL
+        add_instruction(instructions, 0x1B, ComparisonOperations.exec_shl);
+        // 0x1C - SHR
+        add_instruction(instructions, 0x1C, ComparisonOperations.exec_shr);
 
         // Environment Information
         // 0x38 - CODESIZE

--- a/src/kakarot/instructions/comparison_operations.cairo
+++ b/src/kakarot/instructions/comparison_operations.cairo
@@ -4,7 +4,7 @@
 
 // Starkware dependencies
 from starkware.cairo.common.cairo_builtins import HashBuiltin
-from starkware.cairo.common.uint256 import Uint256, uint256_lt, uint256_signed_lt, uint256_eq
+from starkware.cairo.common.uint256 import Uint256, uint256_lt, uint256_signed_lt, uint256_eq, uint256_shl, uint256_shr
 
 // Internal dependencies
 from kakarot.model import model
@@ -23,6 +23,8 @@ namespace ComparisonOperations {
     const GAS_COST_SGT = 3;
     const GAS_COST_ISZERO = 3;
     const GAS_COST_EQ = 3;
+    const GAS_COST_SHL = 3;
+    const GAS_COST_SHR = 3;
 
     // @notice 0x10 - LT
     // @dev Comparison operation
@@ -241,6 +243,79 @@ namespace ComparisonOperations {
         let ctx = ExecutionContext.update_stack(ctx, stack);
         // Increment gas used.
         let ctx = ExecutionContext.increment_gas_used(ctx, GAS_COST_ISZERO);
+        return ctx;
+    }
+    // @notice 0x1B - SHL
+    // @dev Bitwise operation
+    // @custom:since Constantinople
+    // @custom:group Comparison & Bitwise Logic Operations
+    // @custom:gas 3
+    // @custom:stack_consumed_elements 2
+    // @custom:stack_produced_elements 1
+    // @param ctx The pointer to the execution context.
+    // @return The pointer to the execution context.
+    func exec_shl{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        ctx: model.ExecutionContext*
+    ) -> model.ExecutionContext* {
+        alloc_locals;
+        %{ print("0x1B - SHL") %}
+
+        let stack = ctx.stack;
+
+        // Stack input:
+        // 0 - shift: integer
+        // 1 - value: integer
+        let (stack, shift) = Stack.pop(stack);
+        let (stack, value) = Stack.pop(stack);
+
+        // Left shift `value` by `shift`.
+        let (result) = uint256_shl(value, shift);
+
+        // Stack output:
+        // The result of the shift operation.
+        let stack: model.Stack* = Stack.push(stack, result);
+
+        // Update context stack.
+        let ctx = ExecutionContext.update_stack(ctx, stack);
+        // Increment gas used.
+        let ctx = ExecutionContext.increment_gas_used(ctx, GAS_COST_SHL);
+        return ctx;
+    }
+
+    // @notice 0x1C - SHR
+    // @dev Bitwise operation
+    // @custom:since Constantinople
+    // @custom:group Comparison & Bitwise Logic Operations
+    // @custom:gas 3
+    // @custom:stack_consumed_elements 2
+    // @custom:stack_produced_elements 1
+    // @param ctx The pointer to the execution context.
+    // @return The pointer to the execution context.
+    func exec_shr{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        ctx: model.ExecutionContext*
+    ) -> model.ExecutionContext* {
+        alloc_locals;
+        %{ print("0x1C - SHR") %}
+
+        let stack = ctx.stack;
+
+        // Stack input:
+        // 0 - shift: integer
+        // 1 - value: integer
+        let (stack, shift) = Stack.pop(stack);
+        let (stack, value) = Stack.pop(stack);
+
+        // Right shift `value` by `shift`.
+        let (result) = uint256_shr(value, shift);
+
+        // Stack output:
+        // The result of the shift operation.
+        let stack: model.Stack* = Stack.push(stack, result);
+
+        // Update context stack.
+        let ctx = ExecutionContext.update_stack(ctx, stack);
+        // Increment gas used.
+        let ctx = ExecutionContext.increment_gas_used(ctx, GAS_COST_SHR);
         return ctx;
     }
 }

--- a/tests/cases/003/shl/1.json
+++ b/tests/cases/003/shl/1.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHL",
+  "code": "600160001b",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shl/10.json
+++ b/tests/cases/003/shl/10.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHL",
+  "code": "600060011b",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shl/11.json
+++ b/tests/cases/003/shl/11.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHL",
+  "code": "7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60011b",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shl/2.json
+++ b/tests/cases/003/shl/2.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHL",
+  "code": "600160011b",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shl/3.json
+++ b/tests/cases/003/shl/3.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHL",
+  "code": "600160ff1b",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shl/4.json
+++ b/tests/cases/003/shl/4.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHL",
+  "code": "60016101001b",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shl/5.json
+++ b/tests/cases/003/shl/5.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHL",
+  "code": "60016101011b",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shl/6.json
+++ b/tests/cases/003/shl/6.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHL",
+  "code": "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60001b",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shl/7.json
+++ b/tests/cases/003/shl/7.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHL",
+  "code": "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60011b",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shl/8.json
+++ b/tests/cases/003/shl/8.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHL",
+  "code": "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60ff1b",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shl/9.json
+++ b/tests/cases/003/shl/9.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHL",
+  "code": "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6101001b",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shr/1.json
+++ b/tests/cases/003/shr/1.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHR",
+  "code": "600160001c",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shr/10.json
+++ b/tests/cases/003/shr/10.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHR",
+  "code": "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6101001c",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shr/11.json
+++ b/tests/cases/003/shr/11.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHR",
+  "code": "600060011c",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shr/2.json
+++ b/tests/cases/003/shr/2.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHR",
+  "code": "600160011c",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shr/3.json
+++ b/tests/cases/003/shr/3.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHR",
+  "code": "7f800000000000000000000000000000000000000000000000000000000000000060011c",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shr/4.json
+++ b/tests/cases/003/shr/4.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHR",
+  "code": "7f800000000000000000000000000000000000000000000000000000000000000060ff1c",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shr/5.json
+++ b/tests/cases/003/shr/5.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHR",
+  "code": "7f80000000000000000000000000000000000000000000000000000000000000006101001c",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shr/6.json
+++ b/tests/cases/003/shr/6.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHR",
+  "code": "7f80000000000000000000000000000000000000000000000000000000000000006101011c",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shr/7.json
+++ b/tests/cases/003/shr/7.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHR",
+  "code": "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60001c",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shr/8.json
+++ b/tests/cases/003/shr/8.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHR",
+  "code": "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60011c",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/cases/003/shr/9.json
+++ b/tests/cases/003/shr/9.json
@@ -1,0 +1,6 @@
+{
+  "name": "Comparison & bitwise logic operations - SHR",
+  "code": "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60ff1c",
+  "calldata": "",
+  "expected_return_data": ""
+}

--- a/tests/units/kakarot/test_basic.cairo
+++ b/tests/units/kakarot/test_basic.cairo
@@ -5,6 +5,8 @@
 // Starkware dependencies
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.bool import TRUE, FALSE
+from starkware.cairo.common.math import split_felt
+from starkware.cairo.common.uint256 import Uint256
 
 // Local dependencies
 from kakarot.constants import Constants
@@ -39,13 +41,13 @@ func test_arithmetic_operations{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, 
     let ctx: model.ExecutionContext* = Kakarot.execute(evm_test_case.code, evm_test_case.calldata);
 
     // Assert value on the top of the stack
-    test_utils.assert_top_stack(ctx, 16);
+    test_utils.assert_top_stack(ctx, Uint256(16, 0));
 
     return ();
 }
 
-func _assert_comparison_operation{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    filename: felt, assert_result: felt
+func _assert_operation{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    filename: felt, assert_result: Uint256
 ) {
     // Load test case
     let (evm_test_case: EVMTestCase) = test_utils.load_evm_test_case_from_file(filename);
@@ -67,22 +69,58 @@ func test_comparison_operations{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, 
     let (local context) = prepare();
 
     // Test for LT
-    _assert_comparison_operation('./tests/cases/003_lt.json', 0);
+    _assert_operation('./tests/cases/003_lt.json', Uint256(0, 0));
 
     // Test for GT
-    _assert_comparison_operation('./tests/cases/003_gt.json', 1);
+    _assert_operation('./tests/cases/003_gt.json', Uint256(1, 0));
 
     // Test for SLT
-    _assert_comparison_operation('./tests/cases/003_slt.json', 1);
+    _assert_operation('./tests/cases/003_slt.json', Uint256(1, 0));
 
     // Test for SGT
-    _assert_comparison_operation('./tests/cases/003_sgt.json', 0);
+    _assert_operation('./tests/cases/003_sgt.json', Uint256(0, 0));
 
     // Test for EQ
-    _assert_comparison_operation('./tests/cases/003_eq.json', 0);
+    _assert_operation('./tests/cases/003_eq.json', Uint256(0, 0));
 
     // Test for ISZERO
-    _assert_comparison_operation('./tests/cases/003_iszero.json', 1);
+    _assert_operation('./tests/cases/003_iszero.json', Uint256(1, 0));
+
+    return ();
+}
+
+@external
+func test_bitwise_operations{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    alloc_locals;
+
+    // Prepare Kakarot instance
+    let (local context) = prepare();
+
+    // Test for SHL (from https://eips.ethereum.org/EIPS/eip-145)
+    _assert_operation('./tests/cases/003/shl/1.json', Uint256(1, 0));
+    _assert_operation('./tests/cases/003/shl/2.json', Uint256(2, 0));
+    _assert_operation('./tests/cases/003/shl/3.json', Uint256(0, 0x80000000000000000000000000000000));
+    _assert_operation('./tests/cases/003/shl/4.json', Uint256(0, 0));
+    _assert_operation('./tests/cases/003/shl/5.json', Uint256(0, 0));
+    _assert_operation('./tests/cases/003/shl/6.json', Uint256(0xffffffffffffffffffffffffffffffff, 0xffffffffffffffffffffffffffffffff));
+    _assert_operation('./tests/cases/003/shl/7.json', Uint256(0xfffffffffffffffffffffffffffffffe, 0xffffffffffffffffffffffffffffffff));
+    _assert_operation('./tests/cases/003/shl/8.json', Uint256(0, 0x80000000000000000000000000000000));
+    _assert_operation('./tests/cases/003/shl/9.json', Uint256(0, 0));
+    _assert_operation('./tests/cases/003/shl/10.json', Uint256(0, 0));
+    _assert_operation('./tests/cases/003/shl/11.json', Uint256(0xfffffffffffffffffffffffffffffffe, 0xffffffffffffffffffffffffffffffff));
+
+    // Test for SHR (from https://eips.ethereum.org/EIPS/eip-145)
+    _assert_operation('./tests/cases/003/shr/1.json', Uint256(1, 0));
+    _assert_operation('./tests/cases/003/shr/2.json', Uint256(0, 0));
+    _assert_operation('./tests/cases/003/shr/3.json', Uint256(0, 0x40000000000000000000000000000000));
+    _assert_operation('./tests/cases/003/shr/4.json', Uint256(1, 0));
+    _assert_operation('./tests/cases/003/shr/5.json', Uint256(0, 0));
+    _assert_operation('./tests/cases/003/shr/6.json', Uint256(0, 0));
+    _assert_operation('./tests/cases/003/shr/7.json', Uint256(0xffffffffffffffffffffffffffffffff, 0xffffffffffffffffffffffffffffffff));
+    _assert_operation('./tests/cases/003/shr/8.json', Uint256(0xffffffffffffffffffffffffffffffff, 0x7fffffffffffffffffffffffffffffff));
+    _assert_operation('./tests/cases/003/shr/9.json', Uint256(1, 0));
+    _assert_operation('./tests/cases/003/shr/10.json', Uint256(0, 0));
+    _assert_operation('./tests/cases/003/shr/11.json', Uint256(0, 0));
 
     return ();
 }
@@ -104,7 +142,7 @@ func test_duplication_operations{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*,
     let ctx: model.ExecutionContext* = Kakarot.execute(evm_test_case.code, evm_test_case.calldata);
 
     // Assert value on the top of the stack
-    test_utils.assert_top_stack(ctx, 3);
+    test_utils.assert_top_stack(ctx, Uint256(3, 0));
 
     return ();
 }
@@ -125,7 +163,7 @@ func test_memory_operations{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, rang
     let ctx: model.ExecutionContext* = Kakarot.execute(evm_test_case.code, evm_test_case.calldata);
 
     // Assert value on the top of the memory
-    test_utils.assert_top_memory(ctx, 10);
+    test_utils.assert_top_memory(ctx, Uint256(10, 0));
 
     return ();
 }
@@ -146,7 +184,7 @@ func test_exchange_operations{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ra
     let ctx: model.ExecutionContext* = Kakarot.execute(evm_test_case.code, evm_test_case.calldata);
 
     // Assert value on the top of the stack
-    test_utils.assert_top_stack(ctx, 4);
+    test_utils.assert_top_stack(ctx, Uint256(4, 0));
 
     return ();
 }
@@ -169,7 +207,7 @@ func test_environmental_information{
     let ctx: model.ExecutionContext* = Kakarot.execute(evm_test_case.code, evm_test_case.calldata);
 
     // Assert value on the top of the stack
-    test_utils.assert_top_stack(ctx, 7);
+    test_utils.assert_top_stack(ctx, Uint256(7, 0));
 
     return ();
 }
@@ -189,8 +227,11 @@ func test_block_information{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, rang
     // Run EVM execution
     let ctx: model.ExecutionContext* = Kakarot.execute(evm_test_case.code, evm_test_case.calldata);
 
+    let (high, low) = split_felt(Constants.CHAIN_ID);
+    let chain_id = Uint256(low, high);
+
     // Assert value on the top of the stack
-    test_utils.assert_top_stack(ctx, Constants.CHAIN_ID);
+    test_utils.assert_top_stack(ctx, chain_id);
 
     // Load test case COINBASE
     let (evm_test_case: EVMTestCase) = test_utils.load_evm_test_case_from_file(
@@ -200,8 +241,11 @@ func test_block_information{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, rang
     // Run EVM execution
     let ctx: model.ExecutionContext* = Kakarot.execute(evm_test_case.code, evm_test_case.calldata);
 
+    let (high, low) = split_felt(Constants.COINBASE_ADDRESS);
+    let coinbase_address = Uint256(low, high);
+
     // Assert value on the top of the stack
-    test_utils.assert_top_stack(ctx, Constants.COINBASE_ADDRESS);
+    test_utils.assert_top_stack(ctx, coinbase_address);
 
     return ();
 }

--- a/tests/utils.cairo
+++ b/tests/utils.cairo
@@ -7,6 +7,7 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.cairo.common.uint256 import Uint256, uint256_eq
+from starkware.cairo.common.math import split_felt
 
 // Internal dependencies
 from kakarot.execution_context import ExecutionContext
@@ -54,12 +55,11 @@ namespace test_utils {
     // @param ctx The pointer to the execution context.
     // @param expected_value The expected value.
     func assert_top_stack{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-        ctx: model.ExecutionContext*, expected_value: felt
+        ctx: model.ExecutionContext*, expected_value: Uint256
     ) {
         alloc_locals;
         let (stack, actual) = Stack.pop(ctx.stack);
-        let expected_uint256 = Uint256(expected_value, 0);
-        let (are_equal) = uint256_eq(actual, expected_uint256);
+        let (are_equal) = uint256_eq(actual, expected_value);
         assert are_equal = TRUE;
         return ();
     }
@@ -68,13 +68,12 @@ namespace test_utils {
     // @param ctx The pointer to the execution context.
     // @param expected_value The expected value.
     func assert_top_memory{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-        ctx: model.ExecutionContext*, expected_value: felt
+        ctx: model.ExecutionContext*, expected_value: Uint256
     ) {
         alloc_locals;
         let len = Memory.len(ctx.memory);
         let actual = Memory.load(ctx.memory, len - 1);
-        let expected_uint256 = Uint256(expected_value, 0);
-        let (are_equal) = uint256_eq(actual, expected_uint256);
+        let (are_equal) = uint256_eq(actual, expected_value);
         assert are_equal = TRUE;
         return ();
     }


### PR DESCRIPTION
Core:
- Add 0x1b opcode (shl)
- Add 0x1c opcode (shr)
- Add tests for shl and shr (directly from [EIP-145](https://eips.ethereum.org/EIPS/eip-145))

Non-core:
- Had to change the layout of tests a bit
- Had to update some helper functions to take `Uint256` as input instead of `felt`


Closes #51 
Closes #52 