### PR TITLE
dev: Remove prints in the cairo files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,10 @@ setup:
 	pip install -r requirements.txt
 
 test:
-	pytest -s
+	pytest -s --log-cli-level=INFO
 
 test-integration:
-	pytest tests/integrations -s
+	pytest tests/integrations -s --log-cli-level=INFO
 
 test-units:
-	pytest tests/units -s
-
+	pytest tests/units -s --log-cli-level=INFO

--- a/src/kakarot/execution_context.cairo
+++ b/src/kakarot/execution_context.cairo
@@ -267,16 +267,18 @@ namespace ExecutionContext {
         %}
 
         %{
-            print("===================================")
-            print(f"PROGRAM COUNTER:\t{ids.pc}")
-            print(f"INTRINSIC GAS:\t\t{ids.self.intrinsic_gas_cost}")
-            print(f"GAS USED:\t\t{ids.self.gas_used}")
-            print("*************STACK*****************")
+        import logging
+        logging.info("===================================")
+        logging.info(f"PROGRAM COUNTER:\t{ids.pc}")
+        logging.info(f"INTRINSIC GAS:\t\t{ids.self.intrinsic_gas_cost}")
+        logging.info(f"GAS USED:\t\t{ids.self.gas_used}")
+        logging.info("*************STACK*****************")
         %}
         Stack.dump(self.stack);
         %{
-            print("***********************************")
-            print("===================================")
+        import logging
+        logging.info("***********************************")
+        logging.info("===================================")
         %}
         return ();
     }

--- a/src/kakarot/instructions.cairo
+++ b/src/kakarot/instructions.cairo
@@ -45,7 +45,7 @@ namespace EVMInstructions {
         alloc_locals;
 
         // Retrieve the current program counter.
-        let pc = ctx.program_counter;
+            let pc = ctx.program_counter;
 
         // Revert if pc < 0
         with_attr error_message("Kakarot: InvalidCodeOffset") {
@@ -136,7 +136,10 @@ namespace EVMInstructions {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx_ptr: model.ExecutionContext*) -> model.ExecutionContext* {
-        %{ print("0x00 - STOP") %}
+        %{ 
+        import logging
+        logging.info("0x00 - STOP")
+        %}
         return ExecutionContext.stop(ctx_ptr);
     }
 

--- a/src/kakarot/instructions/arithmetic_operations.cairo
+++ b/src/kakarot/instructions/arithmetic_operations.cairo
@@ -48,7 +48,10 @@ namespace ArithmeticOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x01 - ADD") %}
+        %{ 
+        import logging
+        logging.info("0x01 - ADD") 
+        %}
 
         // Stack input:
         // 0 - a: first integer value to add.
@@ -84,7 +87,10 @@ namespace ArithmeticOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x02 - MUL") %}
+        %{
+        import logging
+        logging.info("0x02 - MUL") 
+        %}
 
         // Stack input:
         // 0 - a: first integer value to multiply.
@@ -119,7 +125,10 @@ namespace ArithmeticOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x03 - SUB") %}
+        %{
+        import logging
+        logging.info("0x03 - SUB") 
+        %}
 
         // Stack input:
         // 0 - a: first integer value to sub.
@@ -154,7 +163,10 @@ namespace ArithmeticOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x04 - DIV") %}
+        %{
+        import logging
+        logging.info("0x04 - DIV")
+        %}
 
         // Stack input:
         // 0 - a: numerator.
@@ -189,7 +201,10 @@ namespace ArithmeticOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x05 - SDIV") %}
+        %{
+        import logging
+        logging.info("0x05 - SDIV")
+        %}
 
         // Stack input:
         // 0 - a: numerator.
@@ -224,7 +239,10 @@ namespace ArithmeticOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x06 - MOD") %}
+        %{
+        import logging
+        logging.info("0x06 - MOD")
+        %}
 
         // Stack input:
         // 0 - a: number.
@@ -259,7 +277,10 @@ namespace ArithmeticOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x07 - SMOD") %}
+        %{
+        import logging
+        logging.info("0x07 - SMOD")
+        %}
 
         // Stack input:
         // 0 - a: number.
@@ -294,7 +315,10 @@ namespace ArithmeticOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x08 - ADDMOD") %}
+        %{
+        import logging
+        logging.info("0x08 - ADDMOD")
+        %}
 
         // Stack input:
         // 0 - a: number.
@@ -333,7 +357,10 @@ namespace ArithmeticOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x09 - MULMOD") %}
+        %{ 
+        import logging
+        logging.info("0x09 - MULMOD")
+        %}
 
         // Stack input:
         // 0 - a: number.
@@ -372,7 +399,10 @@ namespace ArithmeticOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x0A - EXP") %}
+        %{ 
+        import logging
+        logging.info("0x0A - EXP")
+        %}
 
         // Stack input:
         // 0 - a: number.
@@ -407,7 +437,10 @@ namespace ArithmeticOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x0B - SIGNEXTEND") %}
+        %{ 
+        import logging  
+        logging.info("0x0B - SIGNEXTEND")
+        %}
 
         // Stack input:
         // 0 - a: number.

--- a/src/kakarot/instructions/block_information.cairo
+++ b/src/kakarot/instructions/block_information.cairo
@@ -45,7 +45,10 @@ namespace BlockInformation {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
-        %{ print("0x46 - CHAINID") %}
+        %{ 
+        import logging
+        logging.info("0x46 - CHAINID") 
+        %}
         // Get the chain ID.
         let chain_id = Helpers.to_uint256(Constants.CHAIN_ID);
         let stack: model.Stack* = Stack.push(ctx.stack, chain_id);
@@ -72,7 +75,10 @@ namespace BlockInformation {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
-        %{ print("0x41 - COINBASE") %}
+        %{ 
+        import logging
+        logging.info("0x41 - COINBASE")
+        %}
         // Get the coinbase address.
         let coinbase_address = Helpers.to_uint256(Constants.COINBASE_ADDRESS);
         let stack: model.Stack* = Stack.push(ctx.stack, coinbase_address);
@@ -99,7 +105,10 @@ namespace BlockInformation {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
-        %{ print("0x42 - TIMESTAMP") %}
+        %{
+        import logging
+        logging.info("0x42 - TIMESTAMP")
+        %}
         // Get the block’s timestamp
         let (current_timestamp) = get_block_timestamp();
         let (high, low) = split_felt(current_timestamp);
@@ -129,7 +138,10 @@ namespace BlockInformation {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
-        %{ print("0x43 - NUMBER") %}
+        %{
+        import logging
+        logging.info("0x43 - NUMBER")
+        %}
         // Get the block number.
         let (current_block) = get_block_number();
         let (high, low) = split_felt(current_block);
@@ -160,7 +172,10 @@ namespace BlockInformation {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
-        %{ print("0x45 - GASLIMIT") %}
+        %{
+        import logging
+        logging.info("0x45 - GASLIMIT")
+        %}
         // Get the Gas Limit.
 
         let gas_limit = Helpers.to_uint256(ctx.gas_limit);
@@ -189,7 +204,10 @@ namespace BlockInformation {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
-        %{ print("0x44 - DIFFICULTY") %}
+        %{ 
+        import logging
+        logging.info("0x44 - DIFFICULTY")
+        %}
         
         // Get the Difficulty.
         let difficulty = Helpers.to_uint256(0);
@@ -218,7 +236,10 @@ namespace BlockInformation {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
-        %{ print("0x48 - BASEFEE") %}
+        %{
+        import logging
+        logging.info("0x48 - BASEFEE")
+        %}
         
         // Get the base fee.
         let basefee = Helpers.to_uint256(0);

--- a/src/kakarot/instructions/comparison_operations.cairo
+++ b/src/kakarot/instructions/comparison_operations.cairo
@@ -59,7 +59,10 @@ namespace ComparisonOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x10 - LT") %}
+        %{
+        import logging
+        logging.info("0x10 - LT")
+        %}
 
         let stack = ctx.stack;
 
@@ -99,7 +102,10 @@ namespace ComparisonOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x11 - GT") %}
+        %{
+        import logging
+        logging.info("0x11 - GT")
+        %}
 
         let stack = ctx.stack;
 
@@ -139,7 +145,10 @@ namespace ComparisonOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x12 - SLT") %}
+        %{
+        import logging
+        logging.info("0x12 - SLT")
+        %}
 
         let stack = ctx.stack;
 
@@ -179,7 +188,10 @@ namespace ComparisonOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x13 - SGT") %}
+        %{
+        import logging
+        logging.info("0x13 - SGT")
+        %}
 
         let stack = ctx.stack;
 
@@ -219,7 +231,10 @@ namespace ComparisonOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x14 - EQ") %}
+        %{
+        import logging
+        logging.info("0x14 - EQ")
+        %}
 
         let stack = ctx.stack;
 
@@ -259,7 +274,10 @@ namespace ComparisonOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x15 - ISZERO") %}
+        %{
+        import logging
+        logging.info("0x15 - ISZERO")
+        %}
 
         let stack = ctx.stack;
 
@@ -297,7 +315,10 @@ namespace ComparisonOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x16 - AND") %}
+        %{
+        import logging
+        logging.info("0x16 - AND")
+        %}
 
         let stack = ctx.stack;
 
@@ -337,7 +358,10 @@ namespace ComparisonOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x17 - OR") %}
+        %{
+        import logging
+        logging.info("0x17 - OR")
+        %}
 
         let stack = ctx.stack;
 
@@ -377,7 +401,10 @@ namespace ComparisonOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x1B - SHL") %}
+        %{
+        import logging
+        logging.info("0x1B - SHL")
+        %}
 
         let stack = ctx.stack;
 
@@ -417,7 +444,10 @@ namespace ComparisonOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x1C - SHR") %}
+        %{
+        import logging
+        logging.info("0x1C - SHR")
+        %}
 
         let stack = ctx.stack;
 
@@ -454,7 +484,10 @@ namespace ComparisonOperations {
         ctx: model.ExecutionContext*
     ) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x1D - SAR") %}
+        %{
+        import logging
+        logging.info("0x1D - SAR")
+        %}
         let stack = ctx.stack;
 
         // Stack input:
@@ -522,7 +555,10 @@ namespace ComparisonOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x19 - NOT") %}
+        %{
+        import logging
+        logging.info("0x19 - NOT")
+        %}
 
         let stack = ctx.stack;
 

--- a/src/kakarot/instructions/duplication_operations.cairo
+++ b/src/kakarot/instructions/duplication_operations.cairo
@@ -28,8 +28,9 @@ namespace DuplicationOperations {
     }(ctx: model.ExecutionContext*, i: felt) -> model.ExecutionContext* {
         alloc_locals;
         %{
+            import logging
             opcode_value =  127 + ids.i
-            print(f"0x{opcode_value:02x} - DUP{ids.i}")
+            logging.info(f"0x{opcode_value:02x} - DUP{ids.i}")
         %}
 
         // Get stack from context.

--- a/src/kakarot/instructions/environmental_information.cairo
+++ b/src/kakarot/instructions/environmental_information.cairo
@@ -38,7 +38,10 @@ namespace EnvironmentalInformation {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
-        %{ print("0x38 - CODESIZE") %}
+        %{
+        import logging
+        logging.info("0x38 - CODESIZE")
+        %}
         // Get the code size.
         let code_size = Helpers.to_uint256(ctx.code_len);
         let stack: model.Stack* = Stack.push(ctx.stack, code_size);
@@ -65,7 +68,10 @@ namespace EnvironmentalInformation {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
-        %{ print("0x33 - CALLER") %}
+        %{
+        import logging
+        logging.info("0x33 - CALLER")
+        %}
         // Get caller address.
         let (current_address) = get_caller_address();
         let caller_address = Helpers.to_uint256(current_address);
@@ -93,7 +99,10 @@ namespace EnvironmentalInformation {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
-        %{ print("0x3d - RETURNDATASIZE") %}
+        %{
+        import logging
+        logging.info("0x3d - RETURNDATASIZE")
+        %}
         // Get return data size.
         let return_data_size = Helpers.to_uint256(ctx.return_data_len);
         let stack: model.Stack* = Stack.push(ctx.stack, return_data_size);

--- a/src/kakarot/instructions/exchange_operations.cairo
+++ b/src/kakarot/instructions/exchange_operations.cairo
@@ -28,8 +28,9 @@ namespace ExchangeOperations {
     }(ctx: model.ExecutionContext*, i: felt) -> model.ExecutionContext* {
         alloc_locals;
         %{
+            import logging
             opcode_value =  143 + ids.i
-            print(f"0x{opcode_value:02x} - SWAP{ids.i}")
+            logging.info(f"0x{opcode_value:02x} - SWAP{ids.i}")
         %}
 
         // Get stack from context.

--- a/src/kakarot/instructions/memory_operations.cairo
+++ b/src/kakarot/instructions/memory_operations.cairo
@@ -46,7 +46,10 @@ namespace MemoryOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x51 - MLOAD") %}
+        %{ 
+        import logging
+        logging.info("0x51 - MLOAD")
+        %}
 
         let stack = ctx.stack;
 
@@ -86,7 +89,10 @@ namespace MemoryOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x52 - MSTORE") %}
+        %{
+        import logging
+        logging.info("0x52 - MSTORE")
+        %}
 
         let stack = ctx.stack;
 
@@ -122,7 +128,10 @@ namespace MemoryOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x58 - PC") %}
+        %{
+        import logging
+        logging.info("0x58 - PC")
+        %}
         let pc = Helpers.to_uint256(ctx.program_counter - 1);
 
         let stack: model.Stack* = Stack.push(ctx.stack, pc);
@@ -147,7 +156,10 @@ namespace MemoryOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x59 - MSIZE") %}
+        %{ 
+        import logging
+        logging.info("0x59 - MSIZE")
+        %}
         let len = Memory.len(ctx.memory);
         let msize = Helpers.to_uint256(len);
 
@@ -174,7 +186,10 @@ namespace MemoryOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x56 - JUMP") %}
+        %{
+        import logging
+        logging.info("0x56 - JUMP")
+        %}
 
         let stack = ctx.stack;
 
@@ -207,7 +222,10 @@ namespace MemoryOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x57 - JUMPI") %}
+        %{
+        import logging
+        logging.info("0x57 - JUMPI")
+        %}
 
         let stack = ctx.stack;
 
@@ -247,7 +265,10 @@ namespace MemoryOperations {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
-        %{ print("0x5b - JUMPDEST") %}
+        %{
+        import logging
+        logging.info("0x5b - JUMPDEST")
+        %}
         alloc_locals;
         // Increment gas used.
         let ctx = ExecutionContext.increment_gas_used(ctx, GAS_COST_JUMPDEST);
@@ -272,7 +293,8 @@ namespace MemoryOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
         %{
-            print("0x50 - POP")
+        import logging
+        logging.info("0x50 - POP")
         %}
 
         // Get stack from context.

--- a/src/kakarot/instructions/push_operations.cairo
+++ b/src/kakarot/instructions/push_operations.cairo
@@ -32,8 +32,9 @@ namespace PushOperations {
     }(ctx: model.ExecutionContext*, i: felt) -> model.ExecutionContext* {
         alloc_locals;
         %{
+            import logging
             opcode_value =  95 + ids.i
-            print(f"0x{opcode_value:02x} - PUSH{ids.i}")
+            logging.info(f"0x{opcode_value:02x} - PUSH{ids.i}")
         %}
 
         // Get stack from context.

--- a/src/kakarot/instructions/sha3.cairo
+++ b/src/kakarot/instructions/sha3.cairo
@@ -37,7 +37,10 @@ namespace Sha3 {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        %{ print("0x20 - SHA3") %}
+        %{ 
+        import logging
+        logging.info("0x20 - SHA3")
+        %}
 
         let stack = ctx.stack;
 

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -33,7 +33,10 @@ namespace SystemOperations {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
-        %{ print("0xFE - INVALID") %}
+        %{ 
+        import logging
+        logging.info("0xFE - INVALID")
+        %}
         with_attr error_message("Kakarot: 0xFE: Invalid Opcode") {
             assert TRUE = FALSE;
         }

--- a/src/kakarot/memory.cairo
+++ b/src/kakarot/memory.cairo
@@ -140,8 +140,9 @@ namespace Memory {
     }(self: model.Memory*, memory_index: felt) {
         let element = Memory.load(self, memory_index);
         %{
+            import logging
             element_str = cairo_uint256_to_str(ids.element)
-            print(f"{ids.memory_index} - {element_str}")
+            logging.info(f"{ids.memory_index} - {element_str}")
         %}
         return ();
     }

--- a/src/kakarot/stack.cairo
+++ b/src/kakarot/stack.cairo
@@ -279,8 +279,9 @@ namespace Stack {
     }(self: model.Stack*, stack_index: felt) {
         let element = Stack.peek(self, stack_index);
         %{
+            import logging
             element_str = cairo_uint256_to_str(ids.element)
-            print(f"{ids.stack_index} - {element_str}")
+            logging.info(f"{ids.stack_index} - {element_str}")
         %}
         return ();
     }

--- a/tests/utils.cairo
+++ b/tests/utils.cairo
@@ -80,7 +80,10 @@ namespace test_utils {
         let len = Memory.len(ctx.memory);
         let actual = Memory.load(ctx.memory, len - 1);
         let (are_equal) = uint256_eq(actual, expected_value);
-        %{ print(f"actual {ids.actual.low, ids.actual.high}, expected {ids.expected_uint256.low, ids.expected_uint256.high}") %}
+        %{ 
+        import logging
+        logging.info(f"actual {ids.actual.low, ids.actual.high}, expected {ids.expected_uint256.low, ids.expected_uint256.high}") 
+        %}
         assert are_equal = TRUE;
         return ();
     }


### PR DESCRIPTION
Replace the print statements used inside the hints with a python logger

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Right now the cairo programs are printing information using a print statement inside a hint

Issue Number: [126](https://github.com/sayajin-labs/kakarot/issues/126)

## What is the new behavior?

Now we are importing a python logger in the hint and setting the logs with an info level
