### PR TITLE
Feat/add 0x47 SELFBALANCE opcode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ clean:
 	mkdir build
 
 run-test:
-	poetry run pytest tests/test_zk_evm.py::TestZkEVM -k $(test)
+	poetry run pytest tests/test_zk_evm.py::TestZkEVM -k $(test) -s --log-cli-level=INFO
 
 format-mac:
 	cairo-format src/**/*.cairo -i

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ production.
 ```mermaid
 %%{init: {'theme': 'forest', 'themeVariables': { 'darkMode': 'false'}}}%%
 
-pie title Kakarot EMV opcodes support (122 / 142)
-    "Supported" : 122
-    "Not supported" : 20
+pie title Kakarot EMV opcodes support (123 / 142)
+    "Supported" : 123
+    "Not supported" : 19
 
     "Partially supported" : 0
 ```

--- a/docs/supported_opcodes.md
+++ b/docs/supported_opcodes.md
@@ -75,7 +75,7 @@ This document describes the opcodes supported by Kakarot.
 | 0x44         | DIFFICULTY  | Get the block's difficulty                                 | ✅          |
 | 0x45         | GASLIMIT    | Get the block's gas limit                                  | ✅          |
 | 0x46         | CHAINID     | Get the chain ID                                           | ✅          |
-| 0x47         | SELFBALANCE | Get the balance of the current contract                    |             |
+| 0x47         | SELFBALANCE | Get the balance of the current contract                    | ✅          |
 | 0x48         | BASEFEE     | Get the base fee of the current block                      | ✅          |
 
 ## Stack, Memory, Storage and Flow Operations

--- a/src/kakarot/instructions.cairo
+++ b/src/kakarot/instructions.cairo
@@ -357,6 +357,10 @@ namespace EVMInstructions {
         add_instruction(
             instructions=instructions, opcode=0x46, function=BlockInformation.exec_chainid
         );
+        // 0x47 - SELFBALANCE
+        add_instruction(
+            instructions=instructions, opcode=0x47, function=BlockInformation.exec_selfbalance
+        );
         // 0x48 - BASEFEE
         add_instruction(
             instructions=instructions, opcode=0x48, function=BlockInformation.exec_basefee

--- a/src/kakarot/instructions/block_information.cairo
+++ b/src/kakarot/instructions/block_information.cairo
@@ -22,49 +22,19 @@ from kakarot.constants import Constants
 // @custom:namespace BlockInformation
 namespace BlockInformation {
     // Define constants.
-    const GAS_COST_CHAINID = 2;
-    const GAS_COST_COINBASE = 2;
-    const GAS_COST_TIMESTAMP = 2;
-    const GAS_COST_NUMBER = 2;
-    const GAS_COST_GASLIMIT = 2;
-    const GAS_COST_DIFFICULTY = 2;
-    const GAS_COST_BASEFEE = 2;
-
-    // @notice CHAINID operation.
-    // @dev Get the chain ID.
-    // @custom:since Instanbul
-    // @custom:group Block Information
-    // @custom:gas 3
-    // @custom:stack_consumed_elements 0
-    // @custom:stack_produced_elements 1
-    // @return The pointer to the updated execution context.
-    func exec_chainid{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr,
-        bitwise_ptr: BitwiseBuiltin*,
-    }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
-        %{
-            import logging
-            logging.info("0x46 - CHAINID")
-        %}
-        // Get the chain ID.
-        let chain_id = Helpers.to_uint256(val=Constants.CHAIN_ID);
-        let stack: model.Stack* = Stack.push(self=ctx.stack, element=chain_id);
-
-        // Update the execution context.
-        // Update context stack.
-        let ctx = ExecutionContext.update_stack(self=ctx, new_stack=stack);
-        // Increment gas used.
-        let ctx = ExecutionContext.increment_gas_used(self=ctx, inc_value=GAS_COST_CHAINID);
-        return ctx;
-    }
+    const GAS_COST_COINBASE    = 2;
+    const GAS_COST_TIMESTAMP   = 2;
+    const GAS_COST_NUMBER      = 2;
+    const GAS_COST_DIFFICULTY  = 2;
+    const GAS_COST_GASLIMIT    = 2;
+    const GAS_COST_CHAINID     = 2;
+    const GAS_COST_BASEFEE     = 2;
 
     // @notice COINBASE operation.
     // @dev Get the block's beneficiary address.
     // @custom:since Frontier
     // @custom:group Block Information
-    // @custom:gas 3
+    // @custom:gas 2
     // @custom:stack_consumed_elements 0
     // @custom:stack_produced_elements 1
     // @return The pointer to the updated execution context.
@@ -155,6 +125,38 @@ namespace BlockInformation {
         return ctx;
     }
 
+    // @notice DIFFICULTY operation.
+    // @dev Get Difficulty
+    // @custom:since Frontier
+    // @custom:group Block Information
+    // @custom:gas 2
+    // @custom:stack_consumed_elements 0
+    // @custom:stack_produced_elements 1
+    // @return The pointer to the updated execution context.
+    func exec_difficulty{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr,
+        bitwise_ptr: BitwiseBuiltin*,
+    }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
+        %{
+            import logging
+            logging.info("0x44 - DIFFICULTY")
+        %}
+
+        // Get the Difficulty.
+        let difficulty = Helpers.to_uint256(val=0);
+
+        let stack: model.Stack* = Stack.push(self=ctx.stack, element=difficulty);
+
+        // Update the execution context.
+        // Update context stack.
+        let ctx = ExecutionContext.update_stack(self=ctx, new_stack=stack);
+        // Increment gas used.
+        let ctx = ExecutionContext.increment_gas_used(self=ctx, inc_value=GAS_COST_DIFFICULTY);
+        return ctx;
+    }
+
     // @notice GASLIMIT operation.
     // @dev Get gas limit
     // @custom:since Frontier
@@ -185,15 +187,15 @@ namespace BlockInformation {
         return ctx;
     }
 
-    // @notice DIFFICULTY operation.
-    // @dev Get Difficulty
-    // @custom:since Frontier
+    // @notice CHAINID operation.
+    // @dev Get the chain ID.
+    // @custom:since Instanbul
     // @custom:group Block Information
     // @custom:gas 2
     // @custom:stack_consumed_elements 0
     // @custom:stack_produced_elements 1
     // @return The pointer to the updated execution context.
-    func exec_difficulty{
+    func exec_chainid{
         syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,
@@ -201,19 +203,17 @@ namespace BlockInformation {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         %{
             import logging
-            logging.info("0x44 - DIFFICULTY")
+            logging.info("0x46 - CHAINID")
         %}
-
-        // Get the Difficulty.
-        let difficulty = Helpers.to_uint256(val=0);
-
-        let stack: model.Stack* = Stack.push(self=ctx.stack, element=difficulty);
+        // Get the chain ID.
+        let chain_id = Helpers.to_uint256(val=Constants.CHAIN_ID);
+        let stack: model.Stack* = Stack.push(self=ctx.stack, element=chain_id);
 
         // Update the execution context.
         // Update context stack.
         let ctx = ExecutionContext.update_stack(self=ctx, new_stack=stack);
         // Increment gas used.
-        let ctx = ExecutionContext.increment_gas_used(self=ctx, inc_value=GAS_COST_DIFFICULTY);
+        let ctx = ExecutionContext.increment_gas_used(self=ctx, inc_value=GAS_COST_CHAINID);
         return ctx;
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ async def eth(starknet):
     return await starknet.deploy(
         source="./tests/utils/ERC20.cairo",
         constructor_calldata=[2] * 6,
+        # Uint256(2, 2) tokens to 2
     )
 
 

--- a/tests/test_zk_evm.py
+++ b/tests/test_zk_evm.py
@@ -652,10 +652,7 @@ test_cases = [
             "return_value": "",
         },
         "id": "Get balance of currently executing contract - 0x47 SELFBALANCE",
-        # TODO: Unmark skip once testing architecture for test_execute and test_execute_address is decoupled
-        "marks": pytest.mark.skip(
-            "Working for test_execute_at_address but not for test_execute, cannot fund zero address."
-        ),
+        "marks": pytest.mark.execute_at_address,
     },
     {
         "params": {
@@ -1265,7 +1262,18 @@ test_cases = [
 ]
 
 
-params = [pytest.param(case.pop("params"), **case) for case in test_cases]
+params_execute = [
+    pytest.param(case.pop("params"), **case)
+    for case in list(
+        filter(lambda x: x.get("marks") != pytest.mark.execute_at_address, test_cases)
+    )
+]
+params_execute_at_address = [
+    pytest.param(case.pop("params"), **case)
+    for case in list(
+        filter(lambda x: x.get("marks") == pytest.mark.execute_at_address, test_cases)
+    )
+]
 
 
 @pytest.mark.asyncio
@@ -1278,7 +1286,7 @@ class TestZkEVM:
 
     @pytest.mark.parametrize(
         "params",
-        params,
+        params_execute,
     )
     async def test_execute(self, zk_evm, params):
         Uint256 = zk_evm.struct_manager.get_contract_struct("Uint256")
@@ -1303,9 +1311,7 @@ class TestZkEVM:
 
     @pytest.mark.parametrize(
         "params",
-        params[:2],
-        # TODO: not sure how of those we want to re-run with the execute_at_address because it is very slow
-        # TODO: This is a magic number.
+        params_execute_at_address,
     )
     async def test_execute_at_address(self, zk_evm, eth, params):
         Uint256 = zk_evm.struct_manager.get_contract_struct("Uint256")

--- a/tests/test_zk_evm.py
+++ b/tests/test_zk_evm.py
@@ -645,6 +645,20 @@ test_cases = [
     },
     {
         "params": {
+            "code": "4700",
+            "calldata": "",
+            "stack": "420",
+            "memory": "",
+            "return_value": "",
+        },
+        "id": "Get balance of currently executing contract - 0x47 SELFBALANCE",
+        # TODO: Unmark skip once testing architecture for test_execute and test_execute_address is decoupled
+        "marks": pytest.mark.skip(
+            "Working for test_execute_at_address but not for test_execute, cannot fund zero address."
+        ),
+    },
+    {
+        "params": {
             "code": "3200",
             "calldata": "",
             "stack": "0",
@@ -1293,12 +1307,21 @@ class TestZkEVM:
         # TODO: not sure how of those we want to re-run with the execute_at_address because it is very slow
         # TODO: This is a magic number.
     )
-    async def test_execute_at_address(self, zk_evm, params):
+    async def test_execute_at_address(self, zk_evm, eth, params):
         Uint256 = zk_evm.struct_manager.get_contract_struct("Uint256")
         tx = await zk_evm.deploy(
             bytes=[int(b, 16) for b in wrap(params["code"], 2)],
         ).execute(caller_address=1)
         evm_contract_address = tx.result.evm_contract_address
+
+        # Fund executing contract address with 420 ETH from original recipient
+        res = await eth.transfer(
+            recipient=tx.result.starknet_contract_address,
+            amount=Uint256(*self.int_to_uint256(420)),
+        ).execute(
+            caller_address=2
+        )  # Original recipient
+        assert res.result.success == 1
 
         res = await zk_evm.execute_at_address(
             address=evm_contract_address,


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #87
Fixes: #87

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Format and rearrange Block Information opcodes accordingly
- 0x47 SELFBALANCE opcode implemented
- Get balance of currently executing contract by getting it from the execution context and querying its balance from the eth contract
- Add distinction among test cases for `test_execute` and `test_execute_at_address`

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
