### PR TITLE
Feat/mload

### DIFF
--- a/docs/mvp/resources/counter.md
+++ b/docs/mvp/resources/counter.md
@@ -45,7 +45,7 @@ contract Counter {
 | CODECOPY     |             |
 | POP          | ✅          |
 | MSTORE       | ✅          |
-| MLOAD        |             |
+| MLOAD        | ✅          |
 | SLOAD        |             |
 | SSTORE       |             |
 | JUMP         | ✅          |

--- a/src/kakarot/instructions.cairo
+++ b/src/kakarot/instructions.cairo
@@ -273,9 +273,10 @@ namespace EVMInstructions {
         add_instruction(instructions, 0x50, MemoryOperations.exec_pop);
 
         // 0x51 - MLOAD
-        add_instruction(instructions, 0x51, MemoryOperations.exec_load);
+        add_instruction(instructions, 0x51, MemoryOperations.exec_mload);
         // 0x52 - MSTORE
-        add_instruction(instructions, 0x52, MemoryOperations.exec_store);
+        add_instruction(instructions, 0x52, MemoryOperations.exec_mstore);
+
         // 0x53 - MSTORE8
         add_instruction(instructions, 0x53, MemoryOperations.exec_mstore8);
         // 0x56 - JUMP

--- a/src/kakarot/instructions/memory_operations.cairo
+++ b/src/kakarot/instructions/memory_operations.cairo
@@ -6,6 +6,7 @@
 from starkware.cairo.common.bool import FALSE
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.math import assert_le
+from starkware.cairo.common.math_cmp import is_le
 from starkware.cairo.common.uint256 import Uint256, uint256_unsigned_div_rem
 from starkware.cairo.common.alloc import alloc
 
@@ -67,6 +68,16 @@ namespace MemoryOperations {
         let ctx = ExecutionContext.update_stack(ctx, stack);
         // Increment gas used.
         let ctx = ExecutionContext.increment_gas_used(ctx, GAS_COST_MLOAD);
+
+        // Memory expansion if offset + 32 > MSIZE
+        let is_memory_expansion = is_le(ctx.memory.bytes_len, offset.low + 32);
+        if (is_memory_expansion == 1) {
+            let memory = Memory.store(self=ctx.memory, element=value, offset=offset.low);
+            let ctx = ExecutionContext.update_memory(ctx, memory);
+            let ctx = ExecutionContext.increment_gas_used(ctx, GAS_COST_MSTORE);
+            return ctx;
+        }
+
         return ctx;
     }
 

--- a/src/kakarot/instructions/memory_operations.cairo
+++ b/src/kakarot/instructions/memory_operations.cairo
@@ -39,7 +39,7 @@ namespace MemoryOperations {
     // @custom:stack_consumed_elements 1
     // @custom:stack_produced_elements 1
     // @return Updated execution context.
-    func exec_load{
+    func exec_mload{
         syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,
@@ -78,7 +78,7 @@ namespace MemoryOperations {
     // @custom:stack_consumed_elements 2
     // @custom:stack_produced_elements 0
     // @return Updated execution context.
-    func exec_store{
+    func exec_mstore{
         syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,

--- a/src/kakarot/memory.cairo
+++ b/src/kakarot/memory.cairo
@@ -6,7 +6,7 @@
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.uint256 import Uint256, uint256_unsigned_div_rem
-from starkware.cairo.common.math_cmp import is_le_felt
+from starkware.cairo.common.math_cmp import is_le_felt, is_le
 from starkware.cairo.common.math import assert_lt, split_int, unsigned_div_rem
 from starkware.cairo.common.memcpy import memcpy
 
@@ -171,7 +171,19 @@ namespace Memory {
         bitwise_ptr: BitwiseBuiltin*,
     }(self: model.Memory*, offset: felt) -> Uint256 {
         alloc_locals;
-        with_attr error_message("Kakarot: MemoryOverflow") {
+
+        // Check if the offset + 32 > MSIZE
+        let offset_out_of_bounds = is_le(self.bytes_len, offset + 32 + 1);
+        if (offset_out_of_bounds == 1) {
+            let (local new_memory: felt*) = alloc();
+            memcpy(dst=new_memory, src=self.bytes, len=self.bytes_len);
+            Helpers.fill_zeros(
+                fill_with=offset + 32 - self.bytes_len, arr=new_memory + self.bytes_len
+            );
+            let res: Uint256 = Helpers.felt_as_byte_to_uint256(new_memory + offset);
+            return res;
+        }
+        with_attr error_message("Kakarot: Memory Error") {
             let res: Uint256 = Helpers.felt_as_byte_to_uint256(self.bytes + offset);
         }
         return res;

--- a/tests/cairo_files/instructions/test_memory_operations.cairo
+++ b/tests/cairo_files/instructions/test_memory_operations.cairo
@@ -148,3 +148,35 @@ func test__exec_mload_should_load_a_value_from_memory_with_memory_expansion{
     assert result.memory.bytes_len = test_offset + 32;
     return ();
 }
+
+@external
+func test__exec_mload_should_load_a_value_from_memory_with_offset_larger_than_msize{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() {
+    // Given
+    alloc_locals;
+    let ctx: model.ExecutionContext* = init_context();
+    let test_offset = 684;
+    // Given
+    let stack: model.Stack* = Stack.init();
+    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
+    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0));
+    let ctx = ExecutionContext.update_stack(ctx, stack);
+    let ctx = MemoryOperations.exec_mstore(ctx);
+    let stack: model.Stack* = Stack.push(ctx.stack, Uint256(test_offset, 0));
+    let ctx = ExecutionContext.update_stack(ctx, stack);
+
+    // When
+    let result = MemoryOperations.exec_mload(ctx);
+
+    // Then
+    // TODO - created by Elias - Gas Consumption: Investigate gas consumption for memory expansion
+    // comment: Shouldn't be 9 but higher due to memory expansion
+    assert result.gas_used = 9;
+    let len: felt = Stack.len(result.stack);
+    assert len = 1;
+    let index0 = Stack.peek(result.stack, 0);
+    assert_uint256_eq(index0, Uint256(0, 0));
+    assert result.memory.bytes_len = test_offset + 32;
+    return ();
+}

--- a/tests/cairo_files/instructions/test_memory_operations.cairo
+++ b/tests/cairo_files/instructions/test_memory_operations.cairo
@@ -65,7 +65,7 @@ func test__exec_pc__should_update_after_incrementing{
 }
 
 @external
-func test__exec_pop_should_pop_an_item_from_execution_context {
+func test__exec_pop_should_pop_an_item_from_execution_context{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }() {
     // Given
@@ -86,5 +86,65 @@ func test__exec_pop_should_pop_an_item_from_execution_context {
     assert len = 1;
     let index0 = Stack.peek(result.stack, 0);
     assert_uint256_eq(index0, Uint256(1, 0));
+    return ();
+}
+
+@external
+func test__exec_mload_should_load_a_value_from_memory{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() {
+    // Given
+    alloc_locals;
+    let ctx: model.ExecutionContext* = init_context();
+    // Given
+    let stack: model.Stack* = Stack.init();
+    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
+    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0));
+    let ctx = ExecutionContext.update_stack(ctx, stack);
+    let ctx = MemoryOperations.exec_mstore(ctx);
+    let stack: model.Stack* = Stack.push(ctx.stack, Uint256(0, 0));
+    let ctx = ExecutionContext.update_stack(ctx, stack);
+
+    // When
+    let result = MemoryOperations.exec_mload(ctx);
+
+    // Then
+    assert result.gas_used = 9;
+    let len: felt = Stack.len(result.stack);
+    assert len = 1;
+    let index0 = Stack.peek(result.stack, 0);
+    assert_uint256_eq(index0, Uint256(1, 0));
+    return ();
+}
+
+@external
+func test__exec_mload_should_load_a_value_from_memory_with_memory_expansion{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() {
+    // Given
+    alloc_locals;
+    let ctx: model.ExecutionContext* = init_context();
+    let test_offset = 16;
+    // Given
+    let stack: model.Stack* = Stack.init();
+    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
+    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0));
+    let ctx = ExecutionContext.update_stack(ctx, stack);
+    let ctx = MemoryOperations.exec_mstore(ctx);
+    let stack: model.Stack* = Stack.push(ctx.stack, Uint256(test_offset, 0));
+    let ctx = ExecutionContext.update_stack(ctx, stack);
+
+    // When
+    let result = MemoryOperations.exec_mload(ctx);
+
+    // Then
+    // TODO - created by Elias - Gas Consumption: Investigate gas consumption for memory expansion
+    // comment: Shouldn't be 9 but higher due to memory expansion
+    assert result.gas_used = 9;
+    let len: felt = Stack.len(result.stack);
+    assert len = 1;
+    let index0 = Stack.peek(result.stack, 0);
+    assert_uint256_eq(index0, Uint256(0, 1));
+    assert result.memory.bytes_len = test_offset + 32;
     return ();
 }

--- a/tests/cairo_files/test_memory.cairo
+++ b/tests/cairo_files/test_memory.cairo
@@ -6,7 +6,7 @@
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.bool import TRUE, FALSE
-from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.uint256 import Uint256, assert_uint256_eq
 
 // Local dependencies
 from utils.utils import Helpers
@@ -67,14 +67,56 @@ func test__store__should_add_an_element_to_the_memory{
 func test__load__should_load_an_element_from_the_memory{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }() {
+    alloc_locals;
     // Given
     let memory: model.Memory* = Memory.init();
-    let memory: model.Memory* = Memory.store(memory, Uint256(1, 0), 0);
+    // In the memory, the following values are stored in the order 1, 2, 3, 4 (Big Endian)
+    let memory: model.Memory* = Memory.store(memory, Uint256(low=2, high=1), 0);
+    let memory: model.Memory* = Memory.store(memory, Uint256(low=4, high=3), 32);
 
     // When
     let result = Memory.load(memory, 0);
+
+    %{ print(f"result low: {ids.result.low} | result high: {ids.result.high}") %}
+
     // Then
-    assert result = Uint256(1, 0);
+    assert_uint256_eq(result, Uint256(2, 1));
+
+    // When
+    let result = Memory.load(memory, 32);
+
+    %{ print(f"result low: {ids.result.low} | result high: {ids.result.high}") %}
+    // Then
+    assert_uint256_eq(result, Uint256(4, 3));
+
+    // When
+    let result = Memory.load(memory, 16);
+
+    %{ print(f"result low: {ids.result.low} | result high: {ids.result.high}") %}
+    // Then
+    assert_uint256_eq(result, Uint256(3, 2));
+
+    return ();
+}
+
+@external
+func test__load__should_load_an_element_from_the_memory_with_offset{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}(offset: felt, low: felt, high: felt) {
+    alloc_locals;
+    // Given
+    let memory: model.Memory* = Memory.init();
+    let memory: model.Memory* = Memory.store(memory, Uint256(low=2, high=1), 0);
+    let memory: model.Memory* = Memory.store(memory, Uint256(low=4, high=3), 32);
+
+    // When
+    let result = Memory.load(memory, offset);
+
+    %{ print(f"result low: {ids.result.low} | result high: {ids.result.high}") %}
+
+    // Then
+    assert_uint256_eq(result, Uint256(low, high));
+
     return ();
 }
 

--- a/tests/units/instructions/test_memory_operations.py
+++ b/tests/units/instructions/test_memory_operations.py
@@ -44,3 +44,4 @@ class TestMemoryOperations(IsolatedAsyncioTestCase):
         await self.test_memory_operations.test__exec_pop_should_pop_an_item_from_execution_context().call()
         await self.test_memory_operations.test__exec_mload_should_load_a_value_from_memory().call()
         await self.test_memory_operations.test__exec_mload_should_load_a_value_from_memory_with_memory_expansion().call()
+        await self.test_memory_operations.test__exec_mload_should_load_a_value_from_memory_with_offset_larger_than_msize().call()

--- a/tests/units/instructions/test_memory_operations.py
+++ b/tests/units/instructions/test_memory_operations.py
@@ -42,3 +42,5 @@ class TestMemoryOperations(IsolatedAsyncioTestCase):
             for x in range(1, 15)
         ]
         await self.test_memory_operations.test__exec_pop_should_pop_an_item_from_execution_context().call()
+        await self.test_memory_operations.test__exec_mload_should_load_a_value_from_memory().call()
+        await self.test_memory_operations.test__exec_mload_should_load_a_value_from_memory_with_memory_expansion().call()

--- a/tests/units/test_memory.py
+++ b/tests/units/test_memory.py
@@ -40,7 +40,8 @@ class TestMemory(IsolatedAsyncioTestCase):
         with self.assertRaises(StarkException) as error_msg:
             yield error_msg
         self.assertTrue(
-            f"Error message: {error_message}" in str(error_msg.exception.message)
+            f"Error message: {error_message}" in str(
+                error_msg.exception.message)
         )
 
     async def test_everything_memory(self):
@@ -48,6 +49,11 @@ class TestMemory(IsolatedAsyncioTestCase):
         await self.test_memory.test__len__should_return_the_length_of_the_memory().call()
         await self.test_memory.test__store__should_add_an_element_to_the_memory().call()
         await self.test_memory.test__load__should_load_an_element_from_the_memory().call()
+        await self.test_memory.test__load__should_load_an_element_from_the_memory_with_offset(8, 2 * 256 ** 8, 256 ** 8).call()
+        await self.test_memory.test__load__should_load_an_element_from_the_memory_with_offset(7, 2 * 256 ** 7, 256 ** 7).call()
+        await self.test_memory.test__load__should_load_an_element_from_the_memory_with_offset(23, 3 * 256 ** 7, 2 * 256 ** 7).call()
+        await self.test_memory.test__load__should_load_an_element_from_the_memory_with_offset(33, 4 * 256 ** 1, 3 * 256 ** 1).call()
+        await self.test_memory.test__load__should_load_an_element_from_the_memory_with_offset(63, 0, 4 * 256 ** 15).call()
 
         with self.raisesStarknetError("Kakarot: MemoryOverflow"):
             await self.test_memory.test__load__should_fail__when_out_of_memory().call()

--- a/tests/units/test_memory.py
+++ b/tests/units/test_memory.py
@@ -55,7 +55,4 @@ class TestMemory(IsolatedAsyncioTestCase):
         await self.test_memory.test__load__should_load_an_element_from_the_memory_with_offset(33, 4 * 256 ** 1, 3 * 256 ** 1).call()
         await self.test_memory.test__load__should_load_an_element_from_the_memory_with_offset(63, 0, 4 * 256 ** 15).call()
 
-        with self.raisesStarknetError("Kakarot: MemoryOverflow"):
-            await self.test_memory.test__load__should_fail__when_out_of_memory().call()
-
         await self.test_memory.test__dump__should_print_the_memory().call()

--- a/tests/units/test_memory.py
+++ b/tests/units/test_memory.py
@@ -40,8 +40,7 @@ class TestMemory(IsolatedAsyncioTestCase):
         with self.assertRaises(StarkException) as error_msg:
             yield error_msg
         self.assertTrue(
-            f"Error message: {error_message}" in str(
-                error_msg.exception.message)
+            f"Error message: {error_message}" in str(error_msg.exception.message)
         )
 
     async def test_everything_memory(self):
@@ -49,10 +48,23 @@ class TestMemory(IsolatedAsyncioTestCase):
         await self.test_memory.test__len__should_return_the_length_of_the_memory().call()
         await self.test_memory.test__store__should_add_an_element_to_the_memory().call()
         await self.test_memory.test__load__should_load_an_element_from_the_memory().call()
-        await self.test_memory.test__load__should_load_an_element_from_the_memory_with_offset(8, 2 * 256 ** 8, 256 ** 8).call()
-        await self.test_memory.test__load__should_load_an_element_from_the_memory_with_offset(7, 2 * 256 ** 7, 256 ** 7).call()
-        await self.test_memory.test__load__should_load_an_element_from_the_memory_with_offset(23, 3 * 256 ** 7, 2 * 256 ** 7).call()
-        await self.test_memory.test__load__should_load_an_element_from_the_memory_with_offset(33, 4 * 256 ** 1, 3 * 256 ** 1).call()
-        await self.test_memory.test__load__should_load_an_element_from_the_memory_with_offset(63, 0, 4 * 256 ** 15).call()
+        await self.test_memory.test__load__should_load_an_element_from_the_memory_with_offset(
+            8, 2 * 256**8, 256**8
+        ).call()
+        await self.test_memory.test__load__should_load_an_element_from_the_memory_with_offset(
+            7, 2 * 256**7, 256**7
+        ).call()
+        await self.test_memory.test__load__should_load_an_element_from_the_memory_with_offset(
+            23, 3 * 256**7, 2 * 256**7
+        ).call()
+        await self.test_memory.test__load__should_load_an_element_from_the_memory_with_offset(
+            33, 4 * 256**1, 3 * 256**1
+        ).call()
+        await self.test_memory.test__load__should_load_an_element_from_the_memory_with_offset(
+            63, 0, 4 * 256**15
+        ).call()
+        await self.test_memory.test__load__should_load_an_element_from_the_memory_with_offset(
+            500, 0, 0
+        ).call()
 
         await self.test_memory.test__dump__should_print_the_memory().call()


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Adding Tests for MLOAD opcode 

Noticed behaviour: Does not write zeros at the end of the memory when `offset + 32 > MSIZE`, as per https://www.evm.codes/

<img width="992" alt="image" src="https://user-images.githubusercontent.com/66871571/198406882-1022fc55-265f-493c-acf5-95a58dfe8e24.png">


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adding new test cases to cover byte-sized offsets
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
