### PR TITLE
Add tests for remaining block information instructions

### DIFF
--- a/tests/cairo_files/instructions/test_block_information.cairo
+++ b/tests/cairo_files/instructions/test_block_information.cairo
@@ -6,11 +6,13 @@
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.uint256 import Uint256
+from starkware.starknet.common.syscalls import get_block_number, get_block_timestamp
 
 // Local dependencies
 from utils.utils import Helpers
 from kakarot.model import model
 from kakarot.stack import Stack
+from kakarot.constants import Constants
 from kakarot.execution_context import ExecutionContext
 from kakarot.instructions.block_information import BlockInformation
 
@@ -52,5 +54,70 @@ func test__chainId__should_push_chain_id_to_stack{
     assert len = 1;
     let index0 = Stack.peek(result.stack, 0);
     assert index0 = Uint256(1263227476, 0);
+    return ();
+}
+
+@external
+func test__timestamp_should_push_block_timestamp_to_stack{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() {
+    // Given
+    alloc_locals;
+    let ctx: model.ExecutionContext* = init_context();
+
+    // When
+    let result = BlockInformation.exec_timestamp(ctx);
+
+    // Then
+    assert result.gas_used = 2;
+    let len: felt = Stack.len(result.stack);
+    assert len = 1;
+    let index0 = Stack.peek(result.stack, 0);
+    let (current_timestamp) = get_block_timestamp();
+    let block_timestamp = Helpers.to_uint256(current_timestamp);
+    assert index0 = block_timestamp;
+    return ();
+}
+
+@external
+func test__number_should_push_block_number_to_stack{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() {
+    // Given
+    alloc_locals;
+    let ctx: model.ExecutionContext* = init_context();
+
+    // When
+    let result = BlockInformation.exec_number(ctx);
+
+    // Then
+    assert result.gas_used = 2;
+    let len: felt = Stack.len(result.stack);
+    assert len = 1;
+    let index0 = Stack.peek(result.stack, 0);
+    let (current_block) = get_block_number();
+    let block_number = Helpers.to_uint256(current_block);
+    assert index0 = block_number;
+    return ();
+}
+
+@external
+func test__gaslimit_should_push_gaslimit_to_stack{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() {
+    // Given
+    alloc_locals;
+    let ctx: model.ExecutionContext* = init_context();
+
+    // When
+    let result = BlockInformation.exec_gaslimit(ctx);
+
+    // Then
+    assert result.gas_used = 2;
+    let len: felt = Stack.len(result.stack);
+    assert len = 1;
+    let index0 = Stack.peek(result.stack, 0);
+    let gas_limit = Helpers.to_uint256(ctx.gas_limit);
+    assert index0 = gas_limit;
     return ();
 }

--- a/tests/cairo_files/instructions/test_block_information.cairo
+++ b/tests/cairo_files/instructions/test_block_information.cairo
@@ -36,7 +36,7 @@ func init_context{
 }
 
 @view
-func test__chainId__should_add_0_and_1{
+func test__chainId__should_push_chain_id_to_stack{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }() {
     // Given

--- a/tests/cairo_files/instructions/test_block_information.cairo
+++ b/tests/cairo_files/instructions/test_block_information.cairo
@@ -58,6 +58,27 @@ func test__chainId__should_push_chain_id_to_stack{
 }
 
 @external
+func test__coinbase_should_push_coinbase_address_to_stack{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() {
+    // Given
+    alloc_locals;
+    let ctx: model.ExecutionContext* = init_context();
+
+    // When
+    let result = BlockInformation.exec_coinbase(ctx);
+
+    // Then
+    assert result.gas_used = 2;
+    let len: felt = Stack.len(result.stack);
+    assert len = 1;
+    let index0 = Stack.peek(result.stack, 0);
+    let coinbase_address = Helpers.to_uint256(Constants.MOCK_COINBASE_ADDRESS);
+    assert index0 = coinbase_address;
+    return ();
+}
+
+@external
 func test__timestamp_should_push_block_timestamp_to_stack{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }() {
@@ -119,5 +140,47 @@ func test__gaslimit_should_push_gaslimit_to_stack{
     let index0 = Stack.peek(result.stack, 0);
     let gas_limit = Helpers.to_uint256(ctx.gas_limit);
     assert index0 = gas_limit;
+    return ();
+}
+
+@external
+func test__difficulty_should_push_difficulty_to_stack{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() {
+    // Given
+    alloc_locals;
+    let ctx: model.ExecutionContext* = init_context();
+
+    // When
+    let result = BlockInformation.exec_difficulty(ctx);
+
+    // Then
+    assert result.gas_used = 2;
+    let len: felt = Stack.len(result.stack);
+    assert len = 1;
+    let index0 = Stack.peek(result.stack, 0);
+    let difficulty = Helpers.to_uint256(0);
+    assert index0 = difficulty;
+    return ();
+}
+
+@external
+func test__basefee_should_push_basefee_to_stack{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() {
+    // Given
+    alloc_locals;
+    let ctx: model.ExecutionContext* = init_context();
+
+    // When
+    let result = BlockInformation.exec_basefee(ctx);
+
+    // Then
+    assert result.gas_used = 2;
+    let len: felt = Stack.len(result.stack);
+    assert len = 1;
+    let index0 = Stack.peek(result.stack, 0);
+    let basefee = Helpers.to_uint256(0);
+    assert index0 = basefee;
     return ();
 }

--- a/tests/units/instructions/test_block_information.py
+++ b/tests/units/instructions/test_block_information.py
@@ -35,6 +35,9 @@ class TestBlockInformation(IsolatedAsyncioTestCase):
 
     async def test_everything_block(self):
         await self.test_block_informations.test__chainId__should_push_chain_id_to_stack().call()
+        await self.test_block_informations.test__coinbase_should_push_coinbase_address_to_stack().call()
         await self.test_block_informations.test__timestamp_should_push_block_timestamp_to_stack().call()
         await self.test_block_informations.test__number_should_push_block_number_to_stack().call()
         await self.test_block_informations.test__gaslimit_should_push_gaslimit_to_stack().call()
+        await self.test_block_informations.test__difficulty_should_push_difficulty_to_stack().call()
+        await self.test_block_informations.test__basefee_should_push_basefee_to_stack().call()

--- a/tests/units/instructions/test_block_information.py
+++ b/tests/units/instructions/test_block_information.py
@@ -35,3 +35,6 @@ class TestBlockInformation(IsolatedAsyncioTestCase):
 
     async def test_everything_block(self):
         await self.test_block_informations.test__chainId__should_push_chain_id_to_stack().call()
+        await self.test_block_informations.test__timestamp_should_push_block_timestamp_to_stack().call()
+        await self.test_block_informations.test__number_should_push_block_number_to_stack().call()
+        await self.test_block_informations.test__gaslimit_should_push_gaslimit_to_stack().call()

--- a/tests/units/instructions/test_block_information.py
+++ b/tests/units/instructions/test_block_information.py
@@ -34,4 +34,4 @@ class TestBlockInformation(IsolatedAsyncioTestCase):
         cairo_coverage.report_runs(excluded_file={"site-packages"})
 
     async def test_everything_block(self):
-        await self.test_block_informations.test__chainId__should_add_0_and_1().call()
+        await self.test_block_informations.test__chainId__should_push_chain_id_to_stack().call()


### PR DESCRIPTION
Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [X] Other (please describe): Unit tests of existing functionality

## What is the current behavior?

Of the block information instructions, only CHAINID is unit tested.

## What is the new behavior?

All block information instructions have unit tests.

- Add tests for instructions timestamp, number, and gaslimit which are totally implemented
- Add tests for instructions coinbase, difficulty, and basefee which are implemented but actual values pushed to the stack appear to be stubs. Still, these functions affect the state (e.g. gas consumed) and should be tested IMO. When these instructions are changed to push different values the tests can be tweaked.

I've tried to conform to all code, git, and PR styles. Please let me know if anything should be adjusted.