### PR TITLE
Add memory expansion method and use it in sha3 and exec_mload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,12 @@ isort = "^5.10.1"
 marshmallow-dataclass = "^8.5.9"
 
 [tool.pytest.ini_options]
-asyncio_mode = "auto"
 filterwarnings = [
-    'ignore:Using or importing the ABCs:DeprecationWarning',                                # from frozendict
-    'ignore:lexer_state will be removed in subsequent releases. Use lexer_thread instead.', # from lark
+    "ignore:Using or importing the ABCs:DeprecationWarning",                                # from frozendict
+    "ignore:lexer_state will be removed in subsequent releases. Use lexer_thread instead.", # from lark
 ]
+asyncio_mode = "auto"
+markers = ["sha3"]
 
 [tool.isort]
 profile = "black"

--- a/src/kakarot/instructions/sha3.cairo
+++ b/src/kakarot/instructions/sha3.cairo
@@ -4,13 +4,16 @@
 
 // Starkware dependencies
 from starkware.cairo.common.math import assert_le_felt
+from starkware.cairo.common.math_cmp import is_le_felt
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.cairo_keccak.keccak import keccak_bigend, finalize_keccak
 from starkware.cairo.common.math import unsigned_div_rem
 from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.pow import pow
+from starkware.cairo.common.bool import TRUE
 
+from kakarot.memory import Memory
 from kakarot.model import model
 from kakarot.execution_context import ExecutionContext
 from kakarot.stack import Stack
@@ -51,31 +54,19 @@ namespace Sha3 {
         let (stack, offset: Uint256) = Stack.pop(stack);
         let (stack, length: Uint256) = Stack.pop(stack);
 
-        let (local full_64_bits, local remaining_bytes) = unsigned_div_rem(length.low, 8);
+        let (memory, cost) = Memory.insure_length(ctx.memory, offset.low + length.low);
 
         let (local dest: felt*) = alloc();
-
-        if (remaining_bytes != 0) {
-            let last_felt = convert_part_felt(
-                ctx.memory.bytes + offset.low + full_64_bits, remaining_bytes, 0
-            );
-            assert [dest] = last_felt;
-            tempvar range_check_ptr = range_check_ptr;
-        } else {
-            tempvar range_check_ptr = range_check_ptr;
-        }
-
-        if (full_64_bits != 0) {
-            tempvar range_check_ptr = range_check_ptr;
-            convert_full_64_bits(
-                first_byte=ctx.memory.bytes + offset.low + 8 * (full_64_bits - 1),
-                length=full_64_bits,
-                dest=dest + full_64_bits - 1 + remaining_bytes,
-            );
-            tempvar range_check_ptr = range_check_ptr;
-        } else {
-            tempvar range_check_ptr = range_check_ptr;
-        }
+        bytes_to_byte8_little_endian(
+            bytes_len=memory.bytes_len - offset.low,
+            bytes=memory.bytes + offset.low,
+            index=0,
+            size=length.low,
+            byte8=0,
+            byte8_shift=0,
+            dest=dest,
+            dest_index=0,
+        );
 
         let (keccak_ptr: felt*) = alloc();
         local keccak_ptr_start: felt* = keccak_ptr;
@@ -89,27 +80,60 @@ namespace Sha3 {
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
+
         // Increment gas used.
-        let ctx = ExecutionContext.increment_gas_used(ctx, GAS_COST_SHA3);
+        let minimum_word_size = (length.low + 31) / 32;
+        let dynamic_gas = 6 * minimum_word_size + cost;
+
+        let ctx = ExecutionContext.increment_gas_used(ctx, GAS_COST_SHA3 + dynamic_gas);
+        let memory_extension = length.low - ctx.memory.bytes_len + offset.low;
+
         return ctx;
     }
 
-    func convert_full_64_bits(first_byte: felt*, length: felt, dest: felt*) {
-        if (length == 1) {
-            assert [dest] = Helpers.byte_to_64_bits_little_felt(first_byte);
+    func bytes_to_byte8_little_endian{range_check_ptr}(
+        bytes_len: felt,
+        bytes: felt*,
+        index: felt,
+        size: felt,
+        byte8: felt,
+        byte8_shift: felt,
+        dest: felt*,
+        dest_index: felt,
+    ) {
+        alloc_locals;
+        if (index == size) {
             return ();
         }
-        assert [dest] = Helpers.byte_to_64_bits_little_felt(first_byte);
-        return convert_full_64_bits(first_byte - 8, length - 1, dest - 1);
-    }
 
-    func convert_part_felt{range_check_ptr}(val: felt*, length: felt, res: felt) -> felt {
-        if (length == 0) {
-            return res;
+        local current_byte;
+        let out_of_bound = is_le_felt(bytes_len, index);
+        if (out_of_bound == TRUE) {
+            current_byte = 0;
         } else {
-            assert_le_felt(length, 7);
-            let (base) = pow(256, length - 1);
-            return convert_part_felt(val=val + 1, length=length - 1, res=res + [val] * base);
+            assert current_byte = [bytes + index];
         }
+
+        let (bit_shift) = pow(256, byte8_shift);
+
+        let _byte8 = byte8 + bit_shift * current_byte;
+
+        let byte8_full = is_le_felt(7, byte8_shift);
+        let end_of_loop = is_le_felt(size, index + 1);
+        let write_to_dest = is_le_felt(1, byte8_full + end_of_loop);
+        if (write_to_dest == TRUE) {
+            assert dest[dest_index] = _byte8;
+            tempvar _byte8 = 0;
+            tempvar _byte8_shift = 0;
+            tempvar _dest_index = dest_index + 1;
+        } else {
+            tempvar _byte8 = _byte8;
+            tempvar _byte8_shift = byte8_shift + 1;
+            tempvar _dest_index = dest_index;
+        }
+
+        return bytes_to_byte8_little_endian(
+            bytes_len, bytes, index + 1, size, _byte8, _byte8_shift, dest, _dest_index
+        );
     }
 }

--- a/src/kakarot/memory.cairo
+++ b/src/kakarot/memory.cairo
@@ -9,6 +9,7 @@ from starkware.cairo.common.uint256 import Uint256, uint256_unsigned_div_rem
 from starkware.cairo.common.math_cmp import is_le_felt, is_le
 from starkware.cairo.common.math import assert_lt, split_int, unsigned_div_rem
 from starkware.cairo.common.memcpy import memcpy
+from starkware.cairo.common.bool import TRUE
 
 // Internal dependencies
 from kakarot.model import model
@@ -50,12 +51,12 @@ namespace Memory {
         alloc_locals;
         let (new_memory: felt*) = alloc();
         if (self.bytes_len == 0) {
-            Helpers.fill_zeros(fill_with=offset, arr=new_memory);
+            Helpers.fill(arr=new_memory, value=0, length=offset);
         }
         let is_offset_greater_than_length = is_le_felt(self.bytes_len, offset);
         local max_copy: felt;
         if (is_offset_greater_than_length == 1) {
-            Helpers.fill_zeros(fill_with=offset - self.bytes_len, arr=new_memory + self.bytes_len);
+            Helpers.fill(arr=new_memory + self.bytes_len, value=0, length=offset - self.bytes_len);
             max_copy = self.bytes_len;
         } else {
             max_copy = offset;
@@ -112,7 +113,7 @@ namespace Memory {
         alloc_locals;
         let (new_memory: felt*) = alloc();
         if (self.bytes_len == 0) {
-            Helpers.fill_zeros(fill_with=offset, arr=new_memory);
+            Helpers.fill(arr=new_memory, value=0, length=offset);
         }
 
         let is_offset_greater_than_length = is_le_felt(self.bytes_len, offset);
@@ -136,9 +137,9 @@ namespace Memory {
         }
 
         if (is_offset_greater_than_length == 1) {
-            Helpers.fill_zeros(fill_with=offset - self.bytes_len, arr=new_memory + self.bytes_len);
+            Helpers.fill(arr=new_memory + self.bytes_len, value=0, length=offset - self.bytes_len);
             // Fill the unused bytes into 0
-            Helpers.fill_zeros(fill_with=diff, arr=new_memory + total_len);
+            Helpers.fill(arr=new_memory + total_len, value=0, length=diff);
             max_copy = self.bytes_len;
         } else {
             max_copy = offset;
@@ -182,14 +183,14 @@ namespace Memory {
         if (offset_out_of_bounds == 1) {
             let (local new_memory: felt*) = alloc();
             memcpy(dst=new_memory, src=self.bytes, len=self.bytes_len);
-            Helpers.fill_zeros(
-                fill_with=offset + 32 - self.bytes_len, arr=new_memory + self.bytes_len
+            Helpers.fill(
+                arr=new_memory + self.bytes_len, value=0, length=offset + 32 - self.bytes_len
             );
-            let res: Uint256 = Helpers.felt_as_byte_to_uint256(new_memory + offset);
+            let res: Uint256 = Helpers.bytes32_to_uint256(new_memory + offset);
             return res;
         }
         with_attr error_message("Kakarot: Memory Error") {
-            let res: Uint256 = Helpers.felt_as_byte_to_uint256(self.bytes + offset);
+            let res: Uint256 = Helpers.bytes32_to_uint256(self.bytes + offset);
         }
         return res;
     }
@@ -214,5 +215,65 @@ namespace Memory {
             logging.info("************************************")
         %}
         return ();
+    }
+
+    // @notice Expend the memory with length bytes
+    // @param self - The pointer to the memory.
+    // @param length - The number of bytes to add.
+    // @return The new pointer to the memory.
+    // @return The gas cost of this expansion.
+    func expand{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr,
+        bitwise_ptr: BitwiseBuiltin*,
+    }(self: model.Memory*, length: felt) -> (new_memory: model.Memory*, cost: felt) {
+        Helpers.fill(self.bytes + self.bytes_len, value=0, length=length);
+        let (last_memory_size_word, _) = unsigned_div_rem(self.bytes_len + 31, 32);
+        let (last_memory_cost, _) = unsigned_div_rem(
+            last_memory_size_word * last_memory_size_word, 512
+        );
+        let last_memory_cost = last_memory_cost + (3 * last_memory_size_word);
+
+        let (new_memory_size_word, _) = unsigned_div_rem(self.bytes_len + length + 31, 32);
+        let (new_memory_cost, _) = unsigned_div_rem(
+            new_memory_size_word * new_memory_size_word, 512
+        );
+        let new_memory_cost = new_memory_cost + (3 * new_memory_size_word);
+
+        let cost = new_memory_cost - last_memory_cost;
+
+        return (new model.Memory(bytes=self.bytes, bytes_len=self.bytes_len + length), cost);
+    }
+
+    // @notice Insure that the memory as at least length bytes. Expand if necessary.
+    // @param self - The pointer to the memory.
+    // @param offset - The number of bytes to add.
+    // @return The new pointer to the memory.
+    // @return The gas cost of this expansion.
+    func insure_length{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr,
+        bitwise_ptr: BitwiseBuiltin*,
+    }(self: model.Memory*, length: felt) -> (new_memory: model.Memory*, cost: felt) {
+        let is_memory_expanding = is_le_felt(self.bytes_len + 1, length);
+        if (is_memory_expanding == TRUE) {
+            let (new_memory, cost) = Memory.expand(self, length - self.bytes_len);
+            tempvar cost = cost;
+            tempvar syscall_ptr = syscall_ptr;
+            tempvar pedersen_ptr = pedersen_ptr;
+            tempvar range_check_ptr = range_check_ptr;
+            tempvar bitwise_ptr = bitwise_ptr;
+        } else {
+            tempvar new_memory = self;
+            tempvar cost = 0;
+            tempvar syscall_ptr = syscall_ptr;
+            tempvar pedersen_ptr = pedersen_ptr;
+            tempvar range_check_ptr = range_check_ptr;
+            tempvar bitwise_ptr = bitwise_ptr;
+        }
+
+        return (new_memory, cost);
     }
 }

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -170,7 +170,8 @@ namespace Helpers {
         let res = Uint256(low, high);
         return res;
     }
-    func felt_as_byte_to_uint256(val: felt*) -> Uint256 {
+
+    func bytes32_to_uint256(val: felt*) -> Uint256 {
         let res = Uint256(
             low=[val + 16] * 256 ** 15 + [val + 17] * 256 ** 14 + [val + 18] * 256 ** 13 + [val + 19] * 256 ** 12 + [val + 20] * 256 ** 11 + [val + 21] * 256 ** 10 + [val + 22] * 256 ** 9 + [val + 23] * 256 ** 8 + [val + 24] * 256 ** 7 + [val + 25] * 256 ** 6 + [val + 26] * 256 ** 5 + [val + 27] * 256 ** 4 + [val + 28] * 256 ** 3 + [val + 29] * 256 ** 2 + [val + 30] * 256 + [val + 31],
             high=[val] * 256 ** 15 + [val + 1] * 256 ** 14 + [val + 2] * 256 ** 13 + [val + 3] * 256 ** 12 + [val + 4] * 256 ** 11 + [val + 5] * 256 ** 10 + [val + 6] * 256 ** 9 + [val + 7] * 256 ** 8 + [val + 8] * 256 ** 7 + [val + 9] * 256 ** 6 + [val + 10] * 256 ** 5 + [val + 11] * 256 ** 4 + [val + 12] * 256 ** 3 + [val + 13] * 256 ** 2 + [val + 14] * 256 + [val + 15],
@@ -178,16 +179,16 @@ namespace Helpers {
         return res;
     }
 
-    func byte_to_64_bits_little_felt(val: felt*) -> felt {
-        return [val + 7] * 256 ** 7 + [val + 6] * 256 ** 6 + [val + 5] * 256 ** 5 + [val + 4] * 256 ** 4 + [val + 3] * 256 ** 3 + [val + 2] * 256 ** 2 + [val + 1] * 256 + [val];
+    func bytes_to_64_bits_little_felt(bytes: felt*) -> felt {
+        return [bytes + 7] * 256 ** 7 + [bytes + 6] * 256 ** 6 + [bytes + 5] * 256 ** 5 + [bytes + 4] * 256 ** 4 + [bytes + 3] * 256 ** 3 + [bytes + 2] * 256 ** 2 + [bytes + 1] * 256 + [bytes];
     }
 
-    func fill_zeros(fill_with: felt, arr: felt*) {
-        if (fill_with == 0) {
+    func fill(arr: felt*, value: felt, length: felt) {
+        if (length == 0) {
             return ();
         }
-        assert [arr] = 0;
-        return fill_zeros(fill_with - 1, arr + 1);
+        assert [arr] = value;
+        return fill(arr + 1, value, length - 1);
     }
 
     func fill_array(fill_with: felt, input_arr: felt*, output_arr: felt*) {
@@ -219,7 +220,7 @@ namespace Helpers {
 
             let pad_n: felt = slice_len - diff;
 
-            fill_zeros(fill_with=pad_n, arr=sliced_data + diff);
+            fill(arr=sliced_data + diff, value=0, length=pad_n);
         } else {
             memcpy(dst=sliced_data, src=data + data_offset, len=slice_len);
         }

--- a/tests/cairo_files/instructions/test_memory_operations.cairo
+++ b/tests/cairo_files/instructions/test_memory_operations.cairo
@@ -106,10 +106,12 @@ func test__exec_mload_should_load_a_value_from_memory{
     let ctx = ExecutionContext.update_stack(ctx, stack);
 
     // When
+    local gas_used_before = ctx.gas_used;
     let result = MemoryOperations.exec_mload(ctx);
+    local gas_used = result.gas_used - gas_used_before;
 
     // Then
-    assert result.gas_used = 9;
+    assert gas_used = 3;
     let len: felt = Stack.len(result.stack);
     assert len = 1;
     let index0 = Stack.peek(result.stack, 0);
@@ -135,12 +137,12 @@ func test__exec_mload_should_load_a_value_from_memory_with_memory_expansion{
     let ctx = ExecutionContext.update_stack(ctx, stack);
 
     // When
+    local gas_used_before = ctx.gas_used;
     let result = MemoryOperations.exec_mload(ctx);
+    local gas_used = result.gas_used - gas_used_before;
 
     // Then
-    // TODO - created by Elias - Gas Consumption: Investigate gas consumption for memory expansion
-    // comment: Shouldn't be 9 but higher due to memory expansion
-    assert result.gas_used = 9;
+    assert gas_used = 6;
     let len: felt = Stack.len(result.stack);
     assert len = 1;
     let index0 = Stack.peek(result.stack, 0);
@@ -170,9 +172,7 @@ func test__exec_mload_should_load_a_value_from_memory_with_offset_larger_than_ms
     let result = MemoryOperations.exec_mload(ctx);
 
     // Then
-    // TODO - created by Elias - Gas Consumption: Investigate gas consumption for memory expansion
-    // comment: Shouldn't be 9 but higher due to memory expansion
-    assert result.gas_used = 9;
+    assert result.gas_used = 73;
     let len: felt = Stack.len(result.stack);
     assert len = 1;
     let index0 = Stack.peek(result.stack, 0);

--- a/tests/cairo_files/test_memory.cairo
+++ b/tests/cairo_files/test_memory.cairo
@@ -7,6 +7,7 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.cairo.common.uint256 import Uint256, assert_uint256_eq
+from starkware.cairo.common.math import assert_nn
 
 // Local dependencies
 from utils.utils import Helpers
@@ -149,5 +150,91 @@ func test__dump__should_print_the_memory{
 
     // When & Then
     Memory.dump(memory);
+    return ();
+}
+
+@external
+func test__expand__should_return_the_same_memory_and_no_cost{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() {
+    // Given
+    alloc_locals;
+    Helpers.setup_python_defs();
+    let memory = Memory.init();
+    let memory = Memory.store(self=memory, element=Uint256(1, 0), offset=0);
+
+    // When
+    let (memory_expanded, cost) = Memory.expand(self=memory, length=0);
+
+    // Then
+    assert cost = 0;
+    assert memory_expanded.bytes_len = memory.bytes_len;
+    assert [memory_expanded.bytes] = [memory.bytes];
+
+    return ();
+}
+
+@external
+func test__expand__should_return_expanded_memory_and_cost{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() {
+    // Given
+    alloc_locals;
+    Helpers.setup_python_defs();
+    let memory = Memory.init();
+    let memory = Memory.store(self=memory, element=Uint256(1, 0), offset=0);
+
+    // When
+    let (memory_expanded, cost) = Memory.expand(self=memory, length=1);
+
+    // Then
+    assert_nn(cost);
+    assert memory_expanded.bytes_len = memory.bytes_len + 1;
+    assert [memory_expanded.bytes] = [memory.bytes];
+    assert [memory_expanded.bytes] = 0;
+
+    return ();
+}
+
+@external
+func test__insure_length__should_return_the_same_memory_and_no_cost{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() {
+    // Given
+    alloc_locals;
+    Helpers.setup_python_defs();
+    let memory = Memory.init();
+    let memory = Memory.store(self=memory, element=Uint256(1, 0), offset=0);
+
+    // When
+    let (memory_expanded, cost) = Memory.insure_length(self=memory, length=1);
+
+    // Then
+    assert cost = 0;
+    assert memory_expanded.bytes_len = memory.bytes_len;
+    assert [memory_expanded.bytes] = [memory.bytes];
+
+    return ();
+}
+
+@external
+func test__insure_length__should_return_expanded_memory_and_cost{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() {
+    // Given
+    alloc_locals;
+    Helpers.setup_python_defs();
+    let memory = Memory.init();
+    let memory = Memory.store(self=memory, element=Uint256(1, 0), offset=0);
+
+    // When
+    let (memory_expanded, cost) = Memory.insure_length(self=memory, length=33);
+
+    // Then
+    assert_nn(cost);
+    assert memory_expanded.bytes_len = memory.bytes_len + 1;
+    assert [memory_expanded.bytes] = [memory.bytes];
+    assert [memory_expanded.bytes + 32] = 0;
+
     return ();
 }

--- a/tests/test_zk_evm.py
+++ b/tests/test_zk_evm.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from textwrap import wrap
+from time import time
 
 import pytest
 import pytest_asyncio
@@ -7,21 +8,28 @@ import pytest_asyncio
 
 @pytest_asyncio.fixture(scope="session")
 async def zk_evm(starknet, eth):
+    start = time()
     _zk_evm = await starknet.deploy(
         source="./src/kakarot/kakarot.cairo",
         cairo_path=["src"],
         disable_hint_validation=True,
         constructor_calldata=[1, eth.contract_address],
     )
+    evm_time = time()
+    print(f"\nzkEVM deployed in {evm_time - start:.2f}s")
     registry = await starknet.deploy(
         source="./src/kakarot/accounts/registry/account_registry.cairo",
         cairo_path=["src"],
         disable_hint_validation=True,
         constructor_calldata=[_zk_evm.contract_address],
     )
+    registry_time = time()
+    print(f"AccountRegistry deployed in {registry_time - evm_time:.2f}s")
     await _zk_evm.set_account_registry(
         registry_address_=registry.contract_address
     ).execute(caller_address=1)
+    account_time = time()
+    print(f"zkEVM set in {account_time - registry_time:.2f}s")
     return _zk_evm
 
 
@@ -618,7 +626,8 @@ test_cases = [
             "memory": "0000000000000000000000000000000000000000000000000000000000000100",
             "return_value": "",
         },
-        "id": "Sha3 - Hash  32 bytes 0x100",
+        "id": "Hash 32 bytes",
+        "marks": pytest.mark.sha3,
     },
     {
         "params": {
@@ -628,7 +637,41 @@ test_cases = [
             "memory": "0000000000000000000000000000000000000000000000000000000000000010",
             "return_value": "",
         },
-        "id": "Sha3 - Hash 1 byte 0x10",
+        "id": "Hash 1 byte with offset 1f",
+        "marks": pytest.mark.sha3,
+    },
+    {
+        "params": {
+            "code": "6010600052600160002000",
+            "calldata": "",
+            "stack": "85131057757245807317576516368191972321038229705283732634690444270750521936266",
+            "memory": "0000000000000000000000000000000000000000000000000000000000000010",
+            "return_value": "",
+        },
+        "id": "Hash 1 byte no offset",
+        "marks": pytest.mark.sha3,
+    },
+    {
+        "params": {
+            "code": "6010600052600760002000",
+            "calldata": "",
+            "stack": "101225983456080153511598605893998939348063346639131267901574990367534118792751",
+            "memory": "0000000000000000000000000000000000000000000000000000000000000010",
+            "return_value": "",
+        },
+        "id": "Hash 7 bytes",
+        "marks": pytest.mark.sha3,
+    },
+    {
+        "params": {
+            "code": "6010600052600860002000",
+            "calldata": "",
+            "stack": "500549258012437878224561338362079327067368301550791134293299473726337612750",
+            "memory": "0000000000000000000000000000000000000000000000000000000000000010",
+            "return_value": "",
+        },
+        "id": "Hash 8 bytes",
+        "marks": pytest.mark.sha3,
     },
     {
         "params": {
@@ -638,7 +681,19 @@ test_cases = [
             "memory": "0000000000000000000000000000000000000000000000000000000000000010",
             "return_value": "",
         },
-        "id": "Sha3 - Hash 9 bytes 0x10",
+        "id": "Hash 9 bytes",
+        "marks": pytest.mark.sha3,
+    },
+    {
+        "params": {
+            "code": "6010600052601160002000",
+            "calldata": "",
+            "stack": "41382199742381387985558122494590197322490258008471162768551975289239028668781",
+            "memory": "0000000000000000000000000000000000000000000000000000000000000010",
+            "return_value": "",
+        },
+        "id": "Hash 17 bytes",
+        "marks": pytest.mark.sha3,
     },
     {
         "params": {

--- a/tests/units/test_memory.py
+++ b/tests/units/test_memory.py
@@ -68,3 +68,7 @@ class TestMemory(IsolatedAsyncioTestCase):
         ).call()
 
         await self.test_memory.test__dump__should_print_the_memory().call()
+        await self.test_memory.test__expand__should_return_the_same_memory_and_no_cost().call()
+        await self.test_memory.test__expand__should_return_expanded_memory_and_cost().call()
+        await self.test_memory.test__insure_length__should_return_the_same_memory_and_no_cost().call()
+        await self.test_memory.test__insure_length__should_return_expanded_memory_and_cost().call()


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The memory is not expanded on request, and consequent gas consumption is not taken into account.

#120 

## What is the new behavior?

A new `Memory.insure_length` has been created and used in mload and sha3.
It returns a new memory with sufficient length and gas cost (possibly 0) associated with this possible increase.