### PR TITLE
Add forgotten ExecutionContext.update_memory to sha3

### DIFF
--- a/src/kakarot/instructions/sha3.cairo
+++ b/src/kakarot/instructions/sha3.cairo
@@ -56,6 +56,9 @@ namespace Sha3 {
 
         let (memory, cost) = Memory.insure_length(ctx.memory, offset.low + length.low);
 
+        // Update context memory.
+        let ctx = ExecutionContext.update_memory(ctx, memory);
+
         let (local dest: felt*) = alloc();
         bytes_to_byte8_little_endian(
             bytes_len=memory.bytes_len - offset.low,


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

If the memory is expanded during sha3, it is not updated in the context.

## What is the new behavior?

Context is properly updated

## Other information
