### PR TITLE
feat(tests): add tests for CALLDATASIZE and non empty calldata

### DIFF
--- a/tests/test_zk_evm.py
+++ b/tests/test_zk_evm.py
@@ -799,7 +799,17 @@ test_cases = [
             "memory": "",
             "return_value": "",
         },
-        "id": "Get the size of calldata - 0x36 CALLDATASIZE",
+        "id": "Get the size of calldata when empty calldata - 0x36 CALLDATASIZE",
+    },
+    {
+        "params": {
+            "code": "3600",
+            "calldata": "ff",
+            "stack": "1",
+            "memory": "",
+            "return_value": "",
+        },
+        "id": "Get the size of calldata when non empty calldata - 0x36 CALLDATASIZE",
     },
     {
         "params": {


### PR DESCRIPTION
Add test for CALLDATASIZE when CALLDATA is not empty.

Fix @abdelhamidbakhta comment https://github.com/sayajin-labs/kakarot/pull/146/files#r1004043872

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): test coverage

## What is the current behavior?

Currently CALLDATASIZE test only tests that stack is empty with empty CALLDATA. That does not ensure that CALLDATASIZE works well with non empty CALLDATA even if the feature is coded.

Issue Number: N/A

## What is the new behavior?

We add a test with the value 11111111 as CALLDATA and ensure CALLDATASIZE returns the size : 1