### PR TITLE
fix(makefile) update path with new test architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,16 +48,16 @@ lint:
 	amarna ./src/kakarot -o lint.sarif -rules unused-imports,dead-store,unknown-decorator,unused-arguments
 
 run-test-log:
-	poetry run pytest tests/test_zk_evm.py::TestZkEVM -k $(test) -s --log-cli-level=INFO
+	poetry run pytest tests/integrations/test_zk_evm.py::TestZkEVM -k $(test) -s --log-cli-level=INFO
 	
 run-test:
-	poetry run pytest -s -vvv tests/test_zk_evm.py::TestZkEVM::test_execute["$(test)"]
+	poetry run pytest -s -vvv tests/integrations/test_zk_evm.py::TestZkEVM::test_execute["$(test)"]
 
 run-test-mark-log:
-	poetry run pytest tests/test_zk_evm.py::TestZkEVM -m $(mark) -s -vvv --log-cli-level=INFO
+	poetry run pytest tests/integrations/test_zk_evm.py::TestZkEVM -m $(mark) -s -vvv --log-cli-level=INFO
 	
 run-test-mark:
-	poetry run pytest -s tests/test_zk_evm.py::TestZkEVM -m $(mark)
+	poetry run pytest -s tests/integrations/test_zk_evm.py::TestZkEVM -m $(mark)
 
 format-mac:
 	cairo-format src/**/*.cairo -i


### PR DESCRIPTION
We have an issue when running tests locally via makefile.
Makefile does not follow the new test architecture implemented by @ClementWalter 

Tests didn't fail on GitHub actions because we run all the tests

<img width="942" alt="image" src="https://user-images.githubusercontent.com/1172099/202024215-cf7fd62c-9b81-4df8-81c5-8f3be7aa0384.png">

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<img width="942" alt="image" src="https://user-images.githubusercontent.com/1172099/202024270-09126d8d-63a6-49ab-9cf2-99102c0d4db3.png">

## What is the new behavior?

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/1172099/202024349-73714c78-a1e6-4666-99c2-18516147bc46.png">