### PR TITLE
Update check-resources to display all historical data and not only main

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -899,6 +899,17 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 six = ">=1.5"
 
 [[package]]
+name = "python-dotenv"
+version = "0.21.0"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "pytz"
 version = "2022.6"
 description = "World timezone definitions, modern and historical"
@@ -1123,7 +1134,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "c339630d5f1bec02c906e0c41b5749a063f230ceabf083bcb72f9c6f8bc9d5fe"
+content-hash = "5c4d97d9895ca1b1486f063ed95e20e8edb65bac96b5a449a03e5fd73eb94ade"
 
 [metadata.files]
 aiohttp = [
@@ -1990,6 +2001,10 @@ pytest-xdist = [
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+python-dotenv = [
+    {file = "python-dotenv-0.21.0.tar.gz", hash = "sha256:b77d08274639e3d34145dfa6c7008e66df0f04b7be7a75fd0d5292c191d79045"},
+    {file = "python_dotenv-0.21.0-py3-none-any.whl", hash = "sha256:1684eb44636dd462b66c3ee016599815514527ad99965de77f43e0944634a7e5"},
 ]
 pytz = [
     {file = "pytz-2022.6-py2.py3-none-any.whl", hash = "sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ pytest-xdist = { version = "^3.0.2", extras = ["psutil"] }
 setproctitle = "^1.3.2"
 pysha3 = "^1.0.2"
 web3 = "^5.31.1"
+python-dotenv = "^0.21.0"
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/scripts/check_resources.py
+++ b/scripts/check_resources.py
@@ -6,79 +6,107 @@ from pathlib import Path
 
 import pandas as pd
 import requests
+from dotenv import load_dotenv
 
+load_dotenv()
+pd.set_option("display.max_rows", 500)
+pd.set_option("display.max_columns", 10)
+pd.set_option("display.width", 1000)
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
 def main():
     coverage_dir = Path("coverage")
+    base_branch_name = "main"
 
     #%% Pull latest main artifacts
     response = requests.get(
         "https://api.github.com/repos/sayajin-labs/kakarot/actions/artifacts"
     )
-    latest = sorted(
-        [
-            artifact
-            for artifact in response.json()["artifacts"]
-            if artifact["workflow_run"]["head_branch"] == "main"
-        ],
-        key=lambda artifact: artifact["updated_at"],
-        reverse=True,
+    artifacts = (
+        pd.DataFrame(
+            [
+                {**artifact["workflow_run"], **artifact}
+                for artifact in response.json()["artifacts"]
+            ]
+        )
+        .reindex(["head_branch", "updated_at", "archive_download_url"], axis=1)
+        .sort_values(["head_branch", "updated_at"], ascending=False)
+        .drop_duplicates(["head_branch"])
     )
-
-    if not latest:
-        logger.info("No artifacts found to compare against.")
+    if base_branch_name not in artifacts.head_branch.tolist():
+        logger.info(
+            f"No artifacts found for base branch '{base_branch_name}'. Found\n{artifacts.head_branch.tolist()}"
+        )
         return
 
-    response = requests.get(
-        latest[0]["archive_download_url"],
-        headers={"Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}"},
-    )
+    for artifact in artifacts.to_dict("records"):
+        response = requests.get(
+            artifact["archive_download_url"],
+            headers={"Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}"},
+        )
 
-    z = zipfile.ZipFile(io.BytesIO(response.content))
-    z.extractall(coverage_dir / "main")
+        z = zipfile.ZipFile(io.BytesIO(response.content))
+        z.extractall(coverage_dir / artifact["head_branch"])
 
     #%% Build aggregated stat for checking resources evolution
-    resources_main = (
-        pd.read_csv("./coverage/main/resources.csv")
-        .assign(
-            id=lambda df: pd.util.hash_pandas_object(
-                df[["contract_name", "function_name", "args", "kwargs"]], index=False
+    resources = [
+        (
+            pd.read_csv(coverage_dir / artifact["head_branch"] / "resources.csv")
+            .assign(
+                id=lambda df: pd.util.hash_pandas_object(
+                    df[["contract_name", "function_name", "args", "kwargs"]],
+                    index=False,
+                ),
+                head_branch=artifact["head_branch"],
+            )
+            .drop_duplicates(["id"])
+            .drop(["args", "kwargs", "id"], axis=1)
+        )
+        for artifact in artifacts.to_dict("records")
+    ]
+    if (coverage_dir / "resources.csv").exists():
+        resources.append(
+            (
+                pd.read_csv(coverage_dir / "resources.csv")
+                .assign(
+                    id=lambda df: pd.util.hash_pandas_object(
+                        df[["contract_name", "function_name", "args", "kwargs"]],
+                        index=False,
+                    ),
+                    head_branch="local",
+                )
+                .drop_duplicates(["id"])
+                .drop(["args", "kwargs", "id"], axis=1)
             )
         )
-        .drop_duplicates(["id"])
-        .drop(["args", "kwargs", "id"], axis=1)
-    )
-    resources_branch = (
-        pd.read_csv("./coverage/resources.csv")
-        .assign(
-            id=lambda df: pd.util.hash_pandas_object(
-                df[["contract_name", "function_name", "args", "kwargs"]], index=False
-            )
-        )
-        .drop_duplicates(["id"])
-        .drop(["args", "kwargs", "id"], axis=1)
-    )
 
     resources_change = (
-        pd.concat(
-            [resources_main.assign(ref="main"), resources_branch.assign(ref="branch")]
-        )
-        .groupby("ref")
+        pd.concat(resources)
+        .groupby("head_branch")
         .agg("mean", numeric_only=True)
-        .sort_index(ascending=False)
+        .reset_index()
+        .merge(artifacts[["head_branch", "updated_at"]], on="head_branch")
+        .astype({"updated_at": "datetime64"})
+        .sort_values("updated_at", ascending=False)
+        .drop("updated_at", axis=1)
+        .set_index("head_branch")
+        .astype(int)
     )
-    logger.info(resources_change)
+    logger.info(f"Resources summary:\n{resources_change}")
 
-    if not resources_change.diff().loc["branch"].round().le(0).all():
-        pd.set_option("display.max_rows", 500)
-        pd.set_option("display.max_columns", 500)
-        pd.set_option("display.width", 1000)
-        raise ValueError("Resources usage increase on average with this update")
+    if "local" in resources_change.index:
+        if (
+            not (resources_change.loc["local"] / resources_change.loc[base_branch_name])
+            .le(1)
+            .all()
+        ):
+            raise ValueError("Resources usage increase on average with this update")
+        else:
+            logger.info("Resources usage improved!")
     else:
-        logger.info("Resources usage improved!")
+        logger.info("No local resources found to compare against")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The `check_resources.py` script checks local test reports against the latest one from `main`.
The output of the dataframe in the log is truncated.

## What is the new behavior?

The output is not truncated anymore.
Furthermore, the command display stats not only for main but for all the branches with artifacts.
The command can also be used locally to fetch perf, even though no local artifacts exist.

## Other information

There is still an open question regarding this hard limit on every resources used.