### PR TITLE
Memory using dicts

### DIFF
--- a/src/kakarot/execution_context.cairo
+++ b/src/kakarot/execution_context.cairo
@@ -24,6 +24,17 @@ from kakarot.interfaces.interfaces import IRegistry, IEvmContract
 // @custom:namespace ExecutionContext
 // @custom:model model.ExecutionContext
 namespace ExecutionContext {
+    // Summary of the execution. Created upon finalization of the execution.
+    struct Summary {
+        memory: Memory.Summary*,
+        stack: model.Stack*,
+        return_data: felt*,
+        return_data_len: felt,
+        gas_used: felt,
+        starknet_contract_address: felt,
+        evm_contract_address: felt,
+    }
+
     // @notice Initialize the execution context.
     // @dev set the initial values before executing a piece of code
     // @param call_context The call context.
@@ -60,6 +71,21 @@ namespace ExecutionContext {
             evm_contract_address=0,
             );
         return ctx;
+    }
+
+    // @notice Finalizes the execution context.
+    // @return The pointer to the execution Summary.
+    func finalize{range_check_ptr}(self: model.ExecutionContext*) -> Summary* {
+        let memory_summary = Memory.finalize(self.memory);
+        return new Summary(
+            memory=memory_summary,
+            stack=self.stack,
+            return_data=self.return_data,
+            return_data_len=self.return_data_len,
+            gas_used=self.gas_used,
+            starknet_contract_address=self.starknet_contract_address,
+            evm_contract_address=self.evm_contract_address,
+            );
     }
 
     // @notice Initialize the execution context.

--- a/src/kakarot/instructions/logging_operations.cairo
+++ b/src/kakarot/instructions/logging_operations.cairo
@@ -3,7 +3,7 @@
 %lang starknet
 
 // Starkware dependencies
-
+from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.starknet.common.syscalls import emit_event
 
@@ -49,13 +49,12 @@ namespace LoggingOperations {
             self=ctx.memory, length=actual_size + actual_offset
         );
 
-        // Log topics by emmiting a starknet event
-        emit_event(
-            keys_len=topics_len * 2,
-            keys=popped,
-            data_len=actual_size,
-            data=memory.bytes + actual_offset,
+        // Log topics by emitting a starknet event
+        let (data: felt*) = alloc();
+        let memory = Memory.load_n(
+            self=memory, element_len=actual_size, element=data, offset=actual_offset
         );
+        emit_event(keys_len=topics_len * 2, keys=popped, data_len=actual_size, data=data);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);

--- a/src/kakarot/instructions/memory_operations.cairo
+++ b/src/kakarot/instructions/memory_operations.cairo
@@ -8,7 +8,6 @@ from starkware.cairo.common.uint256 import Uint256, uint256_unsigned_div_rem
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.math_cmp import is_le
 
-
 from kakarot.model import model
 from utils.utils import Helpers
 from kakarot.stack import Stack
@@ -60,7 +59,7 @@ namespace MemoryOperations {
         // Read word from memory at offset
         let (new_memory, cost) = Memory.ensure_length(self=ctx.memory, length=32 + offset.low);
 
-        let value = Memory.load_n(self=new_memory, offset=offset.low, n=32);
+        let (new_memory, value) = Memory.load(self=new_memory, offset=offset.low);
 
         // Push word to the stack
         let stack: model.Stack* = Stack.push(stack, value);
@@ -101,10 +100,7 @@ namespace MemoryOperations {
         let offset = popped[1];
         let value = popped[0];
 
-        
-        let (bytes_array_len, bytes_array) = Helpers.uint256_to_bytes_array(value);
-
-        let memory: model.Memory* = Memory.store_n(self=ctx.memory, element_len=bytes_array_len, element=bytes_array, offset=offset.low);
+        let memory: model.Memory* = Memory.store(self=ctx.memory, element=value, offset=offset.low);
 
         // Update context memory.
         let ctx = ExecutionContext.update_memory(ctx, memory);

--- a/src/kakarot/instructions/sha3.cairo
+++ b/src/kakarot/instructions/sha3.cairo
@@ -54,10 +54,14 @@ namespace Sha3 {
         // Update context memory.
         let ctx = ExecutionContext.update_memory(self=ctx, new_memory=memory);
 
+        let (bigendian_data: felt*) = alloc();
+        let memory = Memory.load_n(
+            self=memory, element_len=length.low, element=bigendian_data, offset=offset.low
+        );
         let (local dest: felt*) = alloc();
         bytes_to_byte8_little_endian(
-            bytes_len=memory.bytes_len - offset.low,
-            bytes=memory.bytes + offset.low,
+            bytes_len=length.low,
+            bytes=bigendian_data,
             index=0,
             size=length.low,
             byte8=0,
@@ -78,6 +82,7 @@ namespace Sha3 {
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
+        let ctx = ExecutionContext.update_memory(ctx, memory);
 
         // Increment gas used.
         let minimum_word_size = (length.low + 31) / 32;

--- a/src/kakarot/kakarot.cairo
+++ b/src/kakarot/kakarot.cairo
@@ -12,6 +12,9 @@ from kakarot.library import Kakarot
 from kakarot.model import model
 from kakarot.stack import Stack
 from kakarot.interfaces.interfaces import IEvmContract
+from kakarot.memory import Memory
+from kakarot.execution_context import ExecutionContext
+from starkware.cairo.common.dict import DictAccess
 
 // Constructor
 @constructor
@@ -30,27 +33,36 @@ func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
 // @param calldata The calldata which can be referenced by the bytecode
 // @return stack_len The length of the stack
 // @return stack The EVM stack content
-// @return memory_len The memory length
+// @return memory_accesses_len The size of the accesses arrayof the memory delta
+// @return memory_accesses The dict accesses in the memory delta
+// @return memory_bytes_len The memory length
 // @return memory The EVM memory content
 // @return gas_used The total amount of gas used to execute the given bytecode
 @view
 func execute{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }(value: felt, bytecode_len: felt, bytecode: felt*, calldata_len: felt, calldata: felt*) -> (
-    stack_len: felt, stack: Uint256*, memory_len: felt, memory: felt*, gas_used: felt
+    stack_len: felt,
+    stack: Uint256*,
+    memory_accesses_len: felt,
+    memory_accesses: felt*,
+    memory_bytes_len: felt,
+    gas_used: felt,
 ) {
     alloc_locals;
     local call_context: model.CallContext* = new model.CallContext(
         bytecode=bytecode, bytecode_len=bytecode_len, calldata=calldata, calldata_len=calldata_len, value=value
         );
-    let context = Kakarot.execute(call_context);
-    let len = Stack.len(context.stack);
+    let summary = Kakarot.execute(call_context);
+    let len = Stack.len(summary.stack);
+    let memory_accesses_len = summary.memory.squashed_end - summary.memory.squashed_start;
     return (
         stack_len=len,
-        stack=context.stack.elements,
-        memory_len=context.memory.bytes_len,
-        memory=context.memory.bytes,
-        gas_used=context.gas_used,
+        stack=summary.stack.elements,
+        memory_accesses_len=memory_accesses_len,
+        memory_accesses=summary.memory.squashed_start,
+        memory_bytes_len=summary.memory.bytes_len,
+        gas_used=summary.gas_used,
     );
 }
 
@@ -62,8 +74,9 @@ func execute{
 // @param calldata The calldata which contains the entry point and method parameters
 // @return stack_len The length of the stack
 // @return stack The EVM stack content
-// @return memory_len The memory length
-// @return memory The EVM memory content
+// @return memory_accesses_len The size of the accesses arrayof the memory delta
+// @return memory_accesses The dict accesses in the memory delta
+// @return memory_bytes_len The memory length
 // @return gas_used The total amount of gas used to execute the given bytecode
 @external
 func execute_at_address{
@@ -71,27 +84,30 @@ func execute_at_address{
 }(address: felt, value: felt, calldata_len: felt, calldata: felt*) -> (
     stack_len: felt,
     stack: Uint256*,
-    memory_len: felt,
-    memory: felt*,
+    memory_accesses_len: felt,
+    memory_accesses: felt*,
+    memory_bytes_len: felt,
     evm_contract_address: felt,
     starknet_contract_address: felt,
     return_data_len: felt,
     return_data: felt*,
 ) {
-    let context = Kakarot.execute_at_address(
+    alloc_locals;
+    let summary = Kakarot.execute_at_address(
         address=address, calldata_len=calldata_len, calldata=calldata, value=value
     );
-
-    let len = Stack.len(context.stack);
+    let len = Stack.len(summary.stack);
+    let memory_accesses_len = summary.memory.squashed_end - summary.memory.squashed_start;
     return (
         stack_len=len,
-        stack=context.stack.elements,
-        memory_len=context.memory.bytes_len,
-        memory=context.memory.bytes,
-        evm_contract_address=context.evm_contract_address,
-        starknet_contract_address=context.starknet_contract_address,
-        return_data_len=context.return_data_len,
-        return_data=context.return_data,
+        stack=summary.stack.elements,
+        memory_accesses_len=memory_accesses_len,
+        memory_accesses=summary.memory.squashed_start,
+        memory_bytes_len=summary.memory.bytes_len,
+        evm_contract_address=summary.evm_contract_address,
+        starknet_contract_address=summary.starknet_contract_address,
+        return_data_len=summary.return_data_len,
+        return_data=summary.return_data,
     );
 }
 

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -63,7 +63,9 @@ namespace Kakarot {
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
-    }(call_context: model.CallContext*) -> model.ExecutionContext* {
+    }(call_context: model.CallContext*) -> ExecutionContext.Summary* {
+        alloc_locals;
+
         // Prepare execution context
         let ctx: model.ExecutionContext* = ExecutionContext.init(call_context);
 
@@ -73,7 +75,11 @@ namespace Kakarot {
         // Start execution
         let ctx = run(ctx=ctx);
 
-        return ctx;
+        // Finalize
+        // TODO: Consider finalizing on `ret` instruction, to get the memory efficiently.
+        let summary = ExecutionContext.finalize(self=ctx);
+
+        return summary;
     }
 
     // @notice execute bytecode of a given EVM contract
@@ -86,7 +92,11 @@ namespace Kakarot {
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
-    }(address: felt, calldata_len: felt, calldata: felt*, value: felt) -> model.ExecutionContext* {
+    }(
+        address: felt, calldata_len: felt, calldata: felt*, value: felt
+    ) -> ExecutionContext.Summary* {
+        alloc_locals;
+
         // Prepare execution context
         let ctx: model.ExecutionContext* = ExecutionContext.init_at_address(
             address=address, calldata_len=calldata_len, calldata=calldata, value=value
@@ -98,7 +108,11 @@ namespace Kakarot {
         // Start execution
         let ctx = run(ctx);
 
-        return ctx;
+        // Finalize
+        // TODO: Consider finalizing on `ret` instruction, to get the memory efficiently.
+        let summary = ExecutionContext.finalize(self=ctx);
+
+        return summary;
     }
 
     // @notice Run the execution of the bytecode.

--- a/src/kakarot/memory.cairo
+++ b/src/kakarot/memory.cairo
@@ -4,12 +4,14 @@
 
 // Starkware dependencies
 from starkware.cairo.common.alloc import alloc
-from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
-from starkware.cairo.common.uint256 import Uint256
-from starkware.cairo.common.math_cmp import is_le
-from starkware.cairo.common.math import split_int, unsigned_div_rem
-from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.bool import TRUE
+from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
+from starkware.cairo.common.dict import DictAccess, dict_read, dict_write
+from starkware.cairo.common.default_dict import default_dict_new, default_dict_finalize
+from starkware.cairo.common.math import split_int, unsigned_div_rem, assert_nn
+from starkware.cairo.common.math_cmp import is_le
+from starkware.cairo.common.memcpy import memcpy
+from starkware.cairo.common.uint256 import Uint256
 
 // Internal dependencies
 from kakarot.model import model
@@ -17,19 +19,116 @@ from utils.utils import Helpers
 
 // @title Memory related functions.
 // @notice This file contains functions related to the memory.
-// @dev The memory is a region that only exists during the smart contract execution, and is accessed with a byte offset.
-// @dev While all the 32-byte address space is available and initialized to 0, the size is counted with the highest address that was accessed.
-// @dev It is generally read and written with `MLOAD` and `MSTORE` instructions, but is also used by other instructions like `CREATE` or `EXTCODECOPY`.
+// @dev The memory is a region that only exists during the smart contract execution, and is accessed
+// @dev with a byte offset.
+// @dev While all the 32-byte address space is available and initialized to 0, the
+// @dev size is counted with the highest address that was accessed.
+// @dev It is generally read and written with `MLOAD` and `MSTORE` instructions,
+// @dev but is also used by other instructions like `CREATE` or `EXTCODECOPY`.
+// @dev The memory representation at model.Memory is a sequence of 128bit (16B) chunks,
+// @dev stored as a dictionary from chunk_index to chunk_value.
+// @dev Each chunk should be read as big endian representation of 16 bytes.
 // @author @abdelhamidbakhta
 // @custom:namespace Memory
 // @custom:model model.Memory
 namespace Memory {
+    // Summary of memory. Created upon finalization of the memory.
+    struct Summary {
+        bytes_len: felt,
+        squashed_start: DictAccess*,
+        squashed_end: DictAccess*,
+    }
+
     // @notice Initialize the memory.
     // @return The pointer to the memory.
     func init() -> model.Memory* {
         alloc_locals;
-        let (bytes: felt*) = alloc();
-        return new model.Memory(bytes=bytes, bytes_len=0);
+        let (word_dict_start: DictAccess*) = default_dict_new(0);
+        return new model.Memory(
+            word_dict_start=word_dict_start,
+            word_dict=word_dict_start,
+            bytes_len=0);
+    }
+
+    // @notice Finalizes the memory.
+    // @return The pointer to the memory Summary.
+    func finalize{range_check_ptr}(self: model.Memory*) -> Summary* {
+        let (squashed_start, squashed_end) = default_dict_finalize(
+            self.word_dict_start, self.word_dict, 0
+        );
+        return new Summary(
+            bytes_len=self.bytes_len, squashed_start=squashed_start, squashed_end=squashed_end
+            );
+    }
+
+    // @notice Store an element into the memory.
+    // @param self - The pointer to the memory.
+    // @param element - The element to push.
+    // @param offset - The offset to store the element at.
+    // @return The new pointer to the memory.
+    func store{range_check_ptr}(
+        self: model.Memory*, element: Uint256, offset: felt
+    ) -> model.Memory* {
+        let word_dict = self.word_dict;
+
+        // Compute new bytes_len.
+        let new_min_bytes_len = offset + 32;
+        let fits = is_le(new_min_bytes_len, self.bytes_len);
+        if (fits == 0) {
+            tempvar new_bytes_len = new_min_bytes_len;
+        } else {
+            tempvar new_bytes_len = self.bytes_len;
+        }
+
+        // Check alignment of offset to 16B chunks.
+        let (chunk_index, offset_in_chunk) = unsigned_div_rem(offset, 16);
+
+        if (offset_in_chunk == 0) {
+            // Offset is aligned. This is the simplest and most efficient case,
+            // so we optimize for it. Note that no locals were allocated at all.
+            dict_write{dict_ptr=word_dict}(chunk_index, element.high);
+            dict_write{dict_ptr=word_dict}(chunk_index + 1, element.low);
+            return (new model.Memory(
+                word_dict_start=self.word_dict_start,
+                word_dict=word_dict,
+                bytes_len=new_bytes_len,
+                ));
+        }
+
+        // Offset is misaligned.
+        // |   W0   |   W1   |   w2   |
+        //     |  EL_H  |  EL_L  |
+        // ^---^
+        //   |-- mask = 256 ** offset_in_chunk
+
+        // Compute mask.
+        tempvar mask = Helpers.pow256_rev(offset_in_chunk);
+        let mask_c = 2 ** 128 / mask;
+
+        // Split the 2 input 16B chunks at offset_in_chunk.
+        let (el_hh, el_hl) = unsigned_div_rem(element.high, mask_c);
+        let (el_lh, el_ll) = unsigned_div_rem(element.low, mask_c);
+
+        // Read the words at chunk_index, chunk_index + 2.
+        let (w0) = dict_read{dict_ptr=word_dict}(chunk_index);
+        let (w2) = dict_read{dict_ptr=word_dict}(chunk_index + 2);
+
+        // Compute the new words.
+        let (w0_h, w0_l) = unsigned_div_rem(w0, mask);
+        let (w2_h, w2_l) = unsigned_div_rem(w2, mask);
+        let new_w0 = w0_h * mask + el_hh;
+        let new_w1 = el_hl * mask + el_lh;
+        let new_w2 = el_ll * mask + w2_l;
+
+        // Write new words.
+        dict_write{dict_ptr=word_dict}(chunk_index, new_w0);
+        dict_write{dict_ptr=word_dict}(chunk_index + 1, new_w1);
+        dict_write{dict_ptr=word_dict}(chunk_index + 2, new_w2);
+        return (new model.Memory(
+            word_dict_start=self.word_dict_start,
+            word_dict=word_dict,
+            bytes_len=new_bytes_len,
+            ));
     }
 
     // @notice store_n Store N bytes into the memory.
@@ -42,39 +141,102 @@ namespace Memory {
         self: model.Memory*, element_len: felt, element: felt*, offset: felt
     ) -> model.Memory* {
         alloc_locals;
-        // New memory is composed of 3 parts: head, element and tail
-        // Head are the bytes before offset.
-        // Head is possibly zero-padded if offset is overbound
-        // Tail are the bytes after element (offset + element_len).
-        // Tail is zero-padded in case the total memory is not a multiple of 32.
+        if (element_len == 0) {
+            return self;
+        }
 
-        local is_memory_expanded: felt;
+        let word_dict = self.word_dict;
 
-        local n_head: felt;
-        local n_head_pad: felt;
-        local n_tail: felt;
-        local n_tail_pad: felt;
+        // Compute new bytes_len.
+        let new_min_bytes_len = offset + element_len;
 
-        let (local new_memory: felt*) = alloc();
+        let (q, r) = unsigned_div_rem(new_min_bytes_len + 31, 32);
+        local new_min_bytes_len = q * 32;
 
-        let is_offset_overbound: felt = is_le(self.bytes_len + 1, offset);
-        let n_head = offset + (self.bytes_len - offset) * is_offset_overbound;
-        let n_head_pad = offset - n_head;
-        let is_memory_expanded = is_le(self.bytes_len + 1, offset + element_len);
-        let n_tail = (self.bytes_len - offset - element_len) * (1 - is_memory_expanded);
-        let (_, rem) = unsigned_div_rem(offset + element_len, 32);
-        let is_rem_positive = is_le(1, rem);
-        let n_tail_pad = (32 - rem) * is_rem_positive * is_memory_expanded;
+        let fits = is_le(new_min_bytes_len, self.bytes_len);
+        local new_bytes_len;
+        if (fits == 0) {
+            new_bytes_len = new_min_bytes_len;
+        } else {
+            new_bytes_len = self.bytes_len;
+        }
 
-        memcpy(dst=new_memory, src=self.bytes, len=n_head);
-        Helpers.fill(arr_len=n_head_pad, arr=new_memory + n_head, value=0);
-        memcpy(dst=new_memory + offset, src=element, len=element_len);
-        memcpy(
-            dst=new_memory + offset + element_len, src=self.bytes + offset + element_len, len=n_tail
+        // Check alignment of offset to 16B chunks.
+        let (chunk_index_i, offset_in_chunk_i) = unsigned_div_rem(offset, 16);
+        let (chunk_index_f, offset_in_chunk_f) = unsigned_div_rem(offset + element_len - 1, 16);
+        tempvar offset_in_chunk_f = offset_in_chunk_f + 1;
+        let mask_i = Helpers.pow256_rev(offset_in_chunk_i);
+        let mask_f = Helpers.pow256_rev(offset_in_chunk_f);
+
+        // Special case: within the same word.
+        if (chunk_index_i == chunk_index_f) {
+            let (w) = dict_read{dict_ptr=word_dict}(chunk_index_i);
+
+            let (w_h, w_l) = Helpers.div_rem(w, mask_i);
+            let (w_lh, w_ll) = Helpers.div_rem(w_l, mask_f);
+            let x = Helpers.load_word(element_len, element);
+            let new_w = w_h * mask_i + x * mask_f + w_ll;
+            dict_write{dict_ptr=word_dict}(chunk_index_i, new_w);
+            return (new model.Memory(
+                word_dict_start=self.word_dict_start,
+                word_dict=word_dict,
+                bytes_len=new_bytes_len));
+        }
+
+        // Otherwise.
+        // Fill first word.
+        let (w_i) = dict_read{dict_ptr=word_dict}(chunk_index_i);
+        let (w_i_h, w_i_l) = Helpers.div_rem(w_i, mask_i);
+        let x_i = Helpers.load_word(16 - offset_in_chunk_i, element);
+        dict_write{dict_ptr=word_dict}(chunk_index_i, w_i_h * mask_i + x_i);
+
+        // Fill last word.
+        let (w_f) = dict_read{dict_ptr=word_dict}(chunk_index_f);
+        let (w_f_h, w_f_l) = Helpers.div_rem(w_f, mask_f);
+        let x_f = Helpers.load_word(offset_in_chunk_f, element + element_len - offset_in_chunk_f);
+        dict_write{dict_ptr=word_dict}(chunk_index_f, x_f * mask_f + w_f_l);
+
+        // Write blocks.
+        let (word_dict) = store_aligned_words(
+            word_dict, chunk_index_i + 1, chunk_index_f, element + 16 - offset_in_chunk_i
         );
-        Helpers.fill(arr_len=n_tail_pad, arr=new_memory + offset + element_len + n_tail, value=0);
-        let new_memory_len: felt = offset + element_len + n_tail + n_tail_pad;
-        return new model.Memory(bytes=new_memory, bytes_len=new_memory_len);
+
+        return (new model.Memory(
+            word_dict_start=self.word_dict_start,
+            word_dict=word_dict,
+            bytes_len=new_bytes_len));
+    }
+
+    func store_aligned_words{range_check_ptr}(
+        word_dict: DictAccess*, chunk_index: felt, chunk_index_f: felt, element: felt*
+    ) -> (word_dict: DictAccess*) {
+        if (chunk_index == chunk_index_f) {
+            return (word_dict=word_dict,);
+        }
+        let current = (
+            element[0] * 256 ** 15 +
+            element[1] * 256 ** 14 +
+            element[2] * 256 ** 13 +
+            element[3] * 256 ** 12 +
+            element[4] * 256 ** 11 +
+            element[5] * 256 ** 10 +
+            element[6] * 256 ** 9 +
+            element[7] * 256 ** 8 +
+            element[8] * 256 ** 7 +
+            element[9] * 256 ** 6 +
+            element[10] * 256 ** 5 +
+            element[11] * 256 ** 4 +
+            element[12] * 256 ** 3 +
+            element[13] * 256 ** 2 +
+            element[14] * 256 ** 1 +
+            element[15] * 256 ** 0);
+        dict_write{dict_ptr=word_dict}(chunk_index, current);
+        return store_aligned_words(
+            word_dict=word_dict,
+            chunk_index=chunk_index + 1,
+            chunk_index_f=chunk_index_f,
+            element=&element[16],
+        );
     }
 
     // @notice Load an element from the memory.
@@ -83,24 +245,131 @@ namespace Memory {
     // @param n - The number of bytes to load from memory.
     // @return The new pointer to the memory.
     // @return The loaded element.
-    func load_n{range_check_ptr}(self: model.Memory*, offset: felt, n: felt) -> Uint256 {
-        alloc_locals;
+    func load{range_check_ptr}(self: model.Memory*, offset: felt) -> (model.Memory*, Uint256) {
+        let word_dict = self.word_dict;
 
-        // Check if the offset + n > MSIZE
-        let offset_out_of_bounds = is_le(self.bytes_len, offset + n + 1);
-        if (offset_out_of_bounds == 1) {
-            let (local new_memory: felt*) = alloc();
-            memcpy(dst=new_memory, src=self.bytes, len=self.bytes_len);
-            Helpers.fill(
-                arr_len=offset + n - self.bytes_len, arr=new_memory + self.bytes_len, value=0
+        // Check alignment of offset to 16B chunks.
+        let (chunk_index, offset_in_chunk) = unsigned_div_rem(offset, 16);
+
+        if (offset_in_chunk == 0) {
+            // Offset is aligned. This is the simplest and most efficient case,
+            // so we optimize for it. Note that no locals were allocated at all.
+            let (el_h) = dict_read{dict_ptr=word_dict}(chunk_index);
+            let (el_l) = dict_read{dict_ptr=word_dict}(chunk_index + 1);
+            return (
+                new model.Memory(
+                word_dict_start=self.word_dict_start,
+                word_dict=word_dict,
+                bytes_len=self.bytes_len,
+                ),
+                Uint256(low=el_l, high=el_h),
             );
-            let res: Uint256 = Helpers.bytes_i_to_uint256(val=new_memory + offset, i=n);
-            return res;
         }
-        with_attr error_message("Kakarot: Memory Error") {
-            let res: Uint256 = Helpers.bytes_i_to_uint256(val=self.bytes + offset, i=n);
+
+        // Offset is misaligned.
+        // |   W0   |   W1   |   w2   |
+        //     |  EL_H  |  EL_L  |
+        //      ^---^
+        //         |-- mask = 256 ** offset_in_chunk
+
+        // Compute mask.
+        tempvar mask = Helpers.pow256_rev(offset_in_chunk);
+        tempvar mask_c = 2 ** 128 / mask;
+
+        // Read words.
+        let (w0) = dict_read{dict_ptr=word_dict}(chunk_index);
+        let (w1) = dict_read{dict_ptr=word_dict}(chunk_index + 1);
+        let (w2) = dict_read{dict_ptr=word_dict}(chunk_index + 2);
+
+        // Compute element words.
+        let (w0_h, w0_l) = unsigned_div_rem(w0, mask);
+        let (w1_h, w1_l) = unsigned_div_rem(w1, mask);
+        let (w2_h, w2_l) = unsigned_div_rem(w2, mask);
+        let el_h = w0_l * mask_c + w1_h;
+        let el_l = w1_l * mask_c + w2_h;
+        return (
+            new model.Memory(
+            word_dict_start=self.word_dict_start,
+            word_dict=word_dict,
+            bytes_len=self.bytes_len,
+            ),
+            Uint256(low=el_l, high=el_h),
+        );
+    }
+
+    // @notice load_n Load N bytes from the memory.
+    // @param self The pointer to the memory.
+    // @param element_len byte length of the output array.
+    // @param element pointer to the output array.
+    // @param offset The memory offset to load from.
+    // @return The new pointer to the memory.
+    func load_n{range_check_ptr}(
+        self: model.Memory*, element_len: felt, element: felt*, offset: felt
+    ) -> model.Memory* {
+        alloc_locals;
+        if (element_len == 0) {
+            return self;
         }
-        return res;
+
+        let word_dict = self.word_dict;
+
+        // Check alignment of offset to 16B chunks.
+        let (chunk_index_i, offset_in_chunk_i) = unsigned_div_rem(offset, 16);
+        let (chunk_index_f, offset_in_chunk_f) = unsigned_div_rem(offset + element_len - 1, 16);
+        tempvar offset_in_chunk_f = offset_in_chunk_f + 1;
+        let mask_i = Helpers.pow256_rev(offset_in_chunk_i);
+        let mask_f = Helpers.pow256_rev(offset_in_chunk_f);
+
+        // Special case: within the same word.
+        if (chunk_index_i == chunk_index_f) {
+            let (w) = dict_read{dict_ptr=word_dict}(chunk_index_i);
+            let (w_h, w_l) = Helpers.div_rem(w, mask_i);
+            let (w_lh, w_ll) = Helpers.div_rem(w_l, mask_f);
+            Helpers.split_word(w_lh, element_len, element);
+            return (new model.Memory(
+                word_dict_start=self.word_dict_start,
+                word_dict=word_dict,
+                bytes_len=self.bytes_len));
+        }
+
+        // Otherwise.
+        // Get first word.
+        let (w_i) = dict_read{dict_ptr=word_dict}(chunk_index_i);
+        let (w_i_h, w_i_l) = Helpers.div_rem(w_i, mask_i);
+        Helpers.split_word(w_i_l, 16 - offset_in_chunk_i, element);
+
+        // Get last word.
+        let (w_f) = dict_read{dict_ptr=word_dict}(chunk_index_f);
+        let (w_f_h, w_f_l) = Helpers.div_rem(w_f, mask_f);
+        Helpers.split_word(w_f_h, offset_in_chunk_f, element + element_len - offset_in_chunk_f);
+
+        // Get blocks.
+        let (word_dict) = load_aligned_words(
+            word_dict, chunk_index_i + 1, chunk_index_f, element + 16 - offset_in_chunk_i
+        );
+
+        return (new model.Memory(
+            word_dict_start=self.word_dict_start,
+            word_dict=word_dict,
+            bytes_len=self.bytes_len));
+    }
+
+    func load_aligned_words{range_check_ptr}(
+        word_dict: DictAccess*, chunk_index: felt, chunk_index_f: felt, element: felt*
+    ) -> (word_dict: DictAccess*) {
+        if (chunk_index == chunk_index_f) {
+            return (word_dict=word_dict,);
+        }
+        let original_word_dict = word_dict;
+        let (value) = dict_read{dict_ptr=word_dict}(chunk_index);
+        let word_dict = original_word_dict + 3;
+        Helpers.split_word_128(value, element);
+        return load_aligned_words(
+            word_dict=word_dict,
+            chunk_index=chunk_index + 1,
+            chunk_index_f=chunk_index_f,
+            element=&element[16],
+        );
     }
 
     // @notice Expend the memory with length bytes
@@ -111,16 +380,14 @@ namespace Memory {
     func expand{range_check_ptr}(self: model.Memory*, length: felt) -> (
         new_memory: model.Memory*, cost: felt
     ) {
-        Helpers.fill(arr_len=length, arr=self.bytes + self.bytes_len, value=0);
         let (last_memory_size_word, _) = unsigned_div_rem(value=self.bytes_len + 31, div=32);
         let (last_memory_cost, _) = unsigned_div_rem(
             value=last_memory_size_word * last_memory_size_word, div=512
         );
         let last_memory_cost = last_memory_cost + (3 * last_memory_size_word);
 
-        let (new_memory_size_word, _) = unsigned_div_rem(
-            value=self.bytes_len + length + 31, div=32
-        );
+        tempvar new_bytes_len = self.bytes_len + length;
+        let (new_memory_size_word, _) = unsigned_div_rem(value=new_bytes_len + 31, div=32);
         let (new_memory_cost, _) = unsigned_div_rem(
             value=new_memory_size_word * new_memory_size_word, div=512
         );
@@ -128,7 +395,14 @@ namespace Memory {
 
         let cost = new_memory_cost - last_memory_cost;
 
-        return (new model.Memory(bytes=self.bytes, bytes_len=self.bytes_len + length), cost);
+        return (
+            new model.Memory(
+            word_dict_start=self.word_dict_start,
+            word_dict=self.word_dict,
+            bytes_len=new_bytes_len,
+            ),
+            cost,
+        );
     }
 
     // @notice Ensure that the memory as at least length bytes. Expand if necessary.
@@ -140,7 +414,7 @@ namespace Memory {
         new_memory: model.Memory*, cost: felt
     ) {
         let is_memory_expanding = is_le(self.bytes_len + 1, length);
-        if (is_memory_expanding == TRUE) {
+        if (is_memory_expanding != 0) {
             let (new_memory, cost) = Memory.expand(self=self, length=length - self.bytes_len);
             return (new_memory, cost);
         } else {

--- a/src/kakarot/model.cairo
+++ b/src/kakarot/model.cairo
@@ -4,6 +4,7 @@
 
 // StarkWare dependencies
 from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.dict import DictAccess
 
 namespace model {
     struct Stack {
@@ -12,8 +13,9 @@ namespace model {
     }
 
     struct Memory {
-        bytes: felt*,
-        bytes_len: felt,  // The size is counted with the highest address that was accessed.
+        word_dict_start: DictAccess*,
+        word_dict: DictAccess*,
+        bytes_len: felt,
     }
 
     struct CallContext {

--- a/tests/cairo_files/test_memory.cairo
+++ b/tests/cairo_files/test_memory.cairo
@@ -52,7 +52,9 @@ func test__store__should_add_an_element_to_the_memory{
     // When
     let value = Uint256(1, 0);
     let (bytes_array_len, bytes_array) = Helpers.uint256_to_bytes_array(value);
-    let result: model.Memory* = Memory.store_n(self=memory, element_len=bytes_array_len, element=bytes_array, offset=0);
+    let result: model.Memory* = Memory.store_n(
+        self=memory, element_len=bytes_array_len, element=bytes_array, offset=0
+    );
 
     // Then
     let len: felt = result.bytes_len;
@@ -72,24 +74,27 @@ func test__load__should_load_an_element_from_the_memory{
     let second_value = Uint256(low=4, high=3);
     let (first_bytes_array_len, first_bytes_array) = Helpers.uint256_to_bytes_array(first_value);
     let (second_bytes_array_len, second_bytes_array) = Helpers.uint256_to_bytes_array(second_value);
-    let memory: model.Memory* = Memory.store_n(self=memory, element_len=first_bytes_array_len, element=first_bytes_array, offset=0);
-    let memory: model.Memory* = Memory.store_n(self=memory, element_len=second_bytes_array_len, element=second_bytes_array, offset=32);
-    
+    let memory: model.Memory* = Memory.store_n(
+        self=memory, element_len=first_bytes_array_len, element=first_bytes_array, offset=0
+    );
+    let memory: model.Memory* = Memory.store_n(
+        self=memory, element_len=second_bytes_array_len, element=second_bytes_array, offset=32
+    );
 
     // When
-    let result = Memory.load_n(memory, 0, 32);
+    let (memory, result) = Memory.load(memory, 0);
 
     // Then
     assert_uint256_eq(result, Uint256(2, 1));
 
     // When
-    let result = Memory.load_n(memory, 32, 32);
+    let (memory, result) = Memory.load(memory, 32);
 
     // Then
     assert_uint256_eq(result, Uint256(4, 3));
 
     // When
-    let result = Memory.load_n(memory, 16, 32);
+    let (memory, result) = Memory.load(memory, 16);
 
     // Then
     assert_uint256_eq(result, Uint256(3, 2));
@@ -109,18 +114,21 @@ func test__load__should_load_an_element_from_the_memory_with_offset{
     let second_value = Uint256(low=4, high=3);
     let (first_bytes_array_len, first_bytes_array) = Helpers.uint256_to_bytes_array(first_value);
     let (second_bytes_array_len, second_bytes_array) = Helpers.uint256_to_bytes_array(second_value);
-    let memory: model.Memory* = Memory.store_n(self=memory, element_len=first_bytes_array_len, element=first_bytes_array, offset=0);
-    let memory: model.Memory* = Memory.store_n(self=memory, element_len=second_bytes_array_len, element=second_bytes_array, offset=32);
+    let memory: model.Memory* = Memory.store_n(
+        self=memory, element_len=first_bytes_array_len, element=first_bytes_array, offset=0
+    );
+    let memory: model.Memory* = Memory.store_n(
+        self=memory, element_len=second_bytes_array_len, element=second_bytes_array, offset=32
+    );
 
     // When
-    let result = Memory.load_n(memory, offset, 32);
+    let (memory, result) = Memory.load(memory, offset);
 
     // Then
     assert_uint256_eq(result, Uint256(low, high));
 
     return ();
 }
-
 
 @external
 func test__expand__should_return_the_same_memory_and_no_cost{
@@ -131,15 +139,18 @@ func test__expand__should_return_the_same_memory_and_no_cost{
     let memory = Memory.init();
     let value = Uint256(1, 0);
     let (bytes_array_len, bytes_array) = Helpers.uint256_to_bytes_array(value);
-    let memory: model.Memory* = Memory.store_n(self=memory, element_len=bytes_array_len, element=bytes_array, offset=0);
+    let memory: model.Memory* = Memory.store_n(
+        self=memory, element_len=bytes_array_len, element=bytes_array, offset=0
+    );
 
     // When
-    let (memory_expanded, cost) = Memory.expand(self=memory, length=0);
+    let (memory, cost) = Memory.expand(self=memory, length=0);
 
     // Then
     assert cost = 0;
-    assert memory_expanded.bytes_len = memory.bytes_len;
-    assert [memory_expanded.bytes] = [memory.bytes];
+    assert memory.bytes_len = 32;
+    let (memory, value) = Memory.load(self=memory, offset=0);
+    assert value = Uint256(1, 0);
 
     return ();
 }
@@ -153,16 +164,18 @@ func test__expand__should_return_expanded_memory_and_cost{
     let memory = Memory.init();
     let value = Uint256(1, 0);
     let (bytes_array_len, bytes_array) = Helpers.uint256_to_bytes_array(value);
-    let memory: model.Memory* = Memory.store_n(self=memory, element_len=bytes_array_len, element=bytes_array, offset=0);
+    let memory: model.Memory* = Memory.store_n(
+        self=memory, element_len=bytes_array_len, element=bytes_array, offset=0
+    );
 
     // When
-    let (memory_expanded, cost) = Memory.expand(self=memory, length=1);
+    let (memory, cost) = Memory.expand(self=memory, length=1);
 
     // Then
     assert_nn(cost);
-    assert memory_expanded.bytes_len = memory.bytes_len + 1;
-    assert [memory_expanded.bytes] = [memory.bytes];
-    assert [memory_expanded.bytes] = 0;
+    assert memory.bytes_len = 33;
+    let (memory, value) = Memory.load(self=memory, offset=0);
+    assert value = Uint256(1, 0);
 
     return ();
 }
@@ -176,15 +189,18 @@ func test__ensure_length__should_return_the_same_memory_and_no_cost{
     let memory = Memory.init();
     let value = Uint256(1, 0);
     let (bytes_array_len, bytes_array) = Helpers.uint256_to_bytes_array(value);
-    let memory: model.Memory* = Memory.store_n(self=memory, element_len=bytes_array_len, element=bytes_array, offset=0);
+    let memory: model.Memory* = Memory.store_n(
+        self=memory, element_len=bytes_array_len, element=bytes_array, offset=0
+    );
 
     // When
-    let (memory_expanded, cost) = Memory.ensure_length(self=memory, length=1);
+    let (memory, cost) = Memory.ensure_length(self=memory, length=1);
 
     // Then
     assert cost = 0;
-    assert memory_expanded.bytes_len = memory.bytes_len;
-    assert [memory_expanded.bytes] = [memory.bytes];
+    assert memory.bytes_len = 32;
+    let (memory, value) = Memory.load(self=memory, offset=0);
+    assert value = Uint256(1, 0);
 
     return ();
 }
@@ -198,16 +214,18 @@ func test__ensure_length__should_return_expanded_memory_and_cost{
     let memory = Memory.init();
     let value = Uint256(1, 0);
     let (bytes_array_len, bytes_array) = Helpers.uint256_to_bytes_array(value);
-    let memory: model.Memory* = Memory.store_n(self=memory, element_len=bytes_array_len, element=bytes_array, offset=0);
+    let memory: model.Memory* = Memory.store_n(
+        self=memory, element_len=bytes_array_len, element=bytes_array, offset=0
+    );
 
     // When
-    let (memory_expanded, cost) = Memory.ensure_length(self=memory, length=33);
+    let (memory, cost) = Memory.ensure_length(self=memory, length=33);
 
     // Then
     assert_nn(cost);
-    assert memory_expanded.bytes_len = memory.bytes_len + 1;
-    assert [memory_expanded.bytes] = [memory.bytes];
-    assert [memory_expanded.bytes + 32] = 0;
+    assert memory.bytes_len = 33;
+    let (memory, value) = Memory.load(self=memory, offset=0);
+    assert value = Uint256(1, 0);
 
     return ();
 }

--- a/tests/integrations/test_zk_evm.py
+++ b/tests/integrations/test_zk_evm.py
@@ -4,7 +4,12 @@ import pytest
 from starkware.starknet.testing.contract import StarknetContract
 
 from tests.integrations.test_cases import params_execute
-from tests.utils.utils import hex_string_to_bytes_array, int_to_uint256, traceit
+from tests.utils.utils import (
+    extract_memory_from_execute,
+    hex_string_to_bytes_array,
+    int_to_uint256,
+    traceit,
+)
 
 
 @pytest.mark.asyncio
@@ -27,7 +32,8 @@ class TestZkEVM:
             for s in (params["stack"].split(",") if params["stack"] else [])
         ]
 
-        assert res.result.memory == hex_string_to_bytes_array(params["memory"])
+        mem = extract_memory_from_execute(res.result)
+        assert mem == hex_string_to_bytes_array(params["memory"])
         events = params.get("events")
         if events:
             assert [

--- a/tests/utils/utils.cairo
+++ b/tests/utils/utils.cairo
@@ -42,11 +42,12 @@ namespace test_utils {
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
-    }(ctx: model.ExecutionContext*, expected_value: Uint256) {
+    }(ctx: model.ExecutionContext*, expected_value: Uint256) -> model.ExecutionContext* {
         alloc_locals;
-        let actual = Memory.load_n(ctx.memory, ctx.memory.end_index - 32, 32);
+        let (memory, actual) = Memory.load(ctx.memory, ctx.memory.end_index - 32);
         let (are_equal) = uint256_eq(actual, expected_value);
         assert are_equal = TRUE;
-        return ();
+        let ctx = ExecutionContext.update_memory(memory);
+        return ctx;
     }
 }

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -355,3 +355,18 @@ def get_contract(contract_name: str) -> Contract:
     contract = Web3().eth.contract(abi=abi, bytecode=bytecode)
     setattr(contract, "_contract_name", contract_name)
     return cast(Contract, contract)
+
+
+def extract_memory_from_execute(result):
+    mem = [0] * result.memory_bytes_len
+    for i in range(0, len(result.memory_accesses), 3):
+        k = result.memory_accesses[i]  # Word index.
+        assert result.memory_accesses[i + 1] == 0  # Initial value.
+        v = result.memory_accesses[i + 2]  # Final value.
+        for j in range(16):
+            if k * 16 + 15 - j < len(mem):
+                mem[k * 16 + 15 - j] = v % 256
+            else:
+                assert v == 0
+            v //= 256
+    return mem


### PR DESCRIPTION
Refactor memryo to use a dictionary of 128bit words.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, memory is represented as an array, and is reallocated entirely on every write.

Issue Number: N/A

## What is the new behavior?

Memory writes and reads will go through a dictionary of packed 128bit words.

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
