### PR TITLE
Remove pull_request_target event

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: TESTS
 
-on: [push, pull_request, pull_request_target]
+on: [push, pull_request]
 
 jobs:
   compilation-tests:

--- a/scripts/check_resources.py
+++ b/scripts/check_resources.py
@@ -12,6 +12,7 @@ load_dotenv()
 pd.set_option("display.max_rows", 500)
 pd.set_option("display.max_columns", 10)
 pd.set_option("display.width", 1000)
+pd.set_option("max_colwidth", 400)
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The CI runs on `pull_request` and `pull_request_target`  target. This later is indeed useless though takes time and make the latest artifact of a branch not reliably the one computed on this branch.

## What is the new behavior?

The worklow simply runs on `pull_request`.
For new branches, `make resources-check` returns consistent metrics.
