### PR TITLE
Profiling data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ python-dotenv = "^0.21.0"
 filterwarnings = [
     "ignore:Using or importing the ABCs:DeprecationWarning",                                # from frozendict
     "ignore:lexer_state will be removed in subsequent releases. Use lexer_thread instead.", # from lark
-    'ignore:abi.encode_abi_packed:DeprecationWarning',                                      # from web3
+    'ignore:abi:DeprecationWarning',                                                        # from web3
 ]
 asyncio_mode = "auto"
 markers = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,12 +32,6 @@ def event_loop():
     loop.close()
 
 
-@pytest.fixture(scope="session", autouse=True)
-def trace_run():
-    ExecuteEntryPoint._run = traceit.trace_run(ExecuteEntryPoint._run)
-    return
-
-
 @pytest_asyncio.fixture(scope="session")
 async def starknet(worker_id) -> AsyncGenerator[Starknet, None]:
     starknet = await Starknet.empty()
@@ -47,6 +41,7 @@ async def starknet(worker_id) -> AsyncGenerator[Starknet, None]:
 
     starknet.deploy = traceit.trace_all(timeit(starknet.deploy))
     starknet.declare = timeit(starknet.declare)
+    ExecuteEntryPoint._run = traceit.trace_run(ExecuteEntryPoint._run)
     output_dir = Path("coverage")
     shutil.rmtree(output_dir, ignore_errors=True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ def event_loop():
     loop.close()
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def trace_run():
     ExecuteEntryPoint._run = traceit.trace_run(ExecuteEntryPoint._run)
     return

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -250,6 +250,7 @@ def dump_reports(path: Union[str, Path]):
     times.to_csv(p / "times.csv", index=False)
     traces.to_csv(p / "resources.csv", index=False)
     for label, runner in _profile_data.items():
+        logger.info(f"Dumping TracerData for runner {label}")
         runner.relocate()
         tracer_data = TracerData(
             program=runner.program,

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import logging
 import os
@@ -195,13 +196,14 @@ class traceit:
             runner, syscall_handler = run(*args, **kwargs)
 
             if cls._context:
-                runner.relocate()
+                _runner = copy.deepcopy(runner)
+                _runner.relocate()
                 tracer_data = TracerData(
-                    program=runner.program,
-                    memory=runner.relocated_memory,
-                    trace=runner.relocated_trace,
+                    program=_runner.program,
+                    memory=_runner.relocated_memory,
+                    trace=_runner.relocated_trace,
                     program_base=1,
-                    debug_info=runner.get_relocated_debug_info(),
+                    debug_info=_runner.get_relocated_debug_info(),
                 )
                 profile = profile_from_tracer_data(tracer_data)
                 _profile_data[cls._context] = profile


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

No profiling data

## What is the new behavior?

Profiling data for each test in pprof format when running tests with the `--trace-run` flag.

## Other information

Generating profiling data is **slow** and consequently disabled by default! When you want to use the tool, just run the target test with `pytest <target test> --trace-run`