### PR TITLE
fix: fix mstore not ceiling to next byte when offset

### DIFF
--- a/src/kakarot/memory.cairo
+++ b/src/kakarot/memory.cairo
@@ -72,7 +72,8 @@ namespace Memory {
         let word_dict = self.word_dict;
 
         // Compute new bytes_len.
-        let new_min_bytes_len = offset + 32;
+        let new_min_bytes_len = Helpers.ceil_bytes_len_to_next_32_bytes_word(offset + 32);
+
         let fits = is_le(new_min_bytes_len, self.bytes_len);
         if (fits == 0) {
             tempvar new_bytes_len = new_min_bytes_len;

--- a/src/kakarot/memory.cairo
+++ b/src/kakarot/memory.cairo
@@ -148,10 +148,7 @@ namespace Memory {
         let word_dict = self.word_dict;
 
         // Compute new bytes_len.
-        let new_min_bytes_len = offset + element_len;
-
-        let (q, r) = unsigned_div_rem(new_min_bytes_len + 31, 32);
-        local new_min_bytes_len = q * 32;
+        let new_min_bytes_len = Helpers.ceil_bytes_len_to_next_32_bytes_word(offset + element_len);
 
         let fits = is_le(new_min_bytes_len, self.bytes_len);
         local new_bytes_len;

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -4,7 +4,13 @@
 
 // StarkWare dependencies
 from starkware.cairo.common.alloc import alloc
-from starkware.cairo.common.math import assert_le, split_felt, assert_nn_le, split_int
+from starkware.cairo.common.math import (
+    assert_le,
+    split_felt,
+    assert_nn_le,
+    split_int,
+    unsigned_div_rem,
+)
 from starkware.cairo.common.math_cmp import is_le
 from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.pow import pow
@@ -475,5 +481,14 @@ namespace Helpers {
 
         assert value = 0;
         return ();
+    }
+
+    // @notice Ceil a number of bits to the next word (32 bytes)
+    // ex: ceil_bytes_len_to_next_32_bytes_word(2) = 32
+    // ex: ceil_bytes_len_to_next_32_bytes_word(34) = 64
+    func ceil_bytes_len_to_next_32_bytes_word{range_check_ptr}(bytes_len: felt) -> felt {
+        let (q, r) = unsigned_div_rem(bytes_len + 31, 32);
+
+        return q * 32;
     }
 }

--- a/tests/integrations/test_cases/execute.py
+++ b/tests/integrations/test_cases/execute.py
@@ -981,6 +981,18 @@ test_cases = [
     {
         "params": {
             "value": 0,
+            "code": "600a60015200",
+            "calldata": "",
+            "stack": "",
+            "memory": "00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000",
+            "return_value": "",
+        },
+        "id": "Memory operations",
+        "marks": [pytest.mark.MSTORE, pytest.mark.StackMemoryStorageFlowOperations],
+    },
+    {
+        "params": {
+            "value": 0,
             "code": "600a60005260fa60245200",
             "calldata": "",
             "stack": "",
@@ -991,7 +1003,6 @@ test_cases = [
         "marks": [
             pytest.mark.MSTORE,
             pytest.mark.StackMemoryStorageFlowOperations,
-            pytest.mark.skip("Returned memory missed the last empty bytes32"),
         ],
     },
     {


### PR DESCRIPTION
Related to: https://github.com/orgs/sayajin-labs/projects/3/views/6?query=is%3Aopen+sort%3Aupdated-desc

Goal of this ticket is to remove the [SKIPPED test](https://github.com/sayajin-labs/kakarot/pull/304/files#diff-33071fb3d4629eb5c6c61cecfc36090d09f4f9b5c408e92088f1df2488cc97a1L994) about mstore.

Currently when there is an offset we increase the memory with the exact necessary size but normal behaviour should be to expand memory to next byte (see for example [evmjs implementation](https://github.com/ethereumjs/ethereumjs-monorepo/blob/985f2aa43c005573382b98423fcfd3bd368b2c8e/packages/evm/src/memory.ts#L30)

Current PR add a test and remove the skipping of the current one in mstore

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):