### PR TITLE
Use internal bytes16 storage, no external API change

### DIFF
--- a/src/kakarot/accounts/contract/library.cairo
+++ b/src/kakarot/accounts/contract/library.cairo
@@ -34,6 +34,8 @@ func storage_(key: Uint256) -> (value: Uint256) {
 func is_initialized_() -> (res: felt) {
 }
 
+// Define the number of bytes per felt. Above 16, the following code won't work as it uses unsigned_div_rem
+// which is bounded by RC_BOUND = 2 ** 128 ~ uint128 ~ bytes16
 const byte_size = 16;
 
 namespace ContractAccount {
@@ -158,6 +160,9 @@ namespace ContractAccount {
 }
 
 namespace internal {
+    // Use a precomputed 2 ** n array to save on resources usage.
+    // Array starts with a 0 to be shifted and have pow[i] = bit shift for byte i with
+    // i as a counter, ie i \in (0, byte_size]
     pow_:
     dw 0;
     dw 1;
@@ -178,7 +183,7 @@ namespace internal {
     dw 2 ** 120;
 
     // @notice Store the bytecode of the contract.
-    // @param index: The index in the bytecode_stored.
+    // @param index: The current free index in the bytecode_ storage.
     // @param bytecode_len: The length of the bytecode.
     // @param bytecode: The bytecode of the contract.
     func write_bytecode{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
@@ -187,20 +192,29 @@ namespace internal {
         alloc_locals;
 
         if (bytecode_len == 0) {
-            // end of bytecode case
+            // end of bytecode case, break loop storing latest "pending" packed felt
             bytecode_.write(index, current_felt);
             return ();
         }
 
         if (remaining_shift == 0) {
-            // end of packed felt case
+            // end of packed felt case, store current "pending" felt
+            // continue loop with a new current_felt and increament index in bytecode_ storage
             bytecode_.write(index, current_felt);
             return write_bytecode(index + 1, bytecode_len, bytecode, 0, byte_size);
         }
 
+        // retrieve the precomputed pow array
         let (pow_address) = get_label_location(pow_);
         let pow = cast(pow_address, felt*);
 
+        // shift the current byte and add it to the current felt
+        // bytes are stored big endian, ie that 3 bytes ends up being stored as a felt whose reprensetation is 0xabcdef000...000
+        // for a given remaining_shift:
+        // current_felt = 0x 12 34 00 00...00 00
+        // bytecode = 0x 56
+        // pow[remaining_shift] * bytecode = 0x 00 00 56 00...00 00
+        // resulting in 0x 12 34 56 00...00 00
         let current_felt = pow[remaining_shift] * [bytecode] + current_felt;
 
         return write_bytecode(
@@ -221,18 +235,24 @@ namespace internal {
         alloc_locals;
 
         if (bytecode_len == 0) {
+            // end of loop
             return ();
         }
 
         if (remaining_shift == 0) {
+            // end of current packed felt, loading next stored felt and increase storage index
             let (current_felt) = bytecode_.read(index);
             return load_bytecode(index + 1, bytecode_len, bytecode, current_felt, byte_size);
         }
 
+        // retrieve the precomputed pow array
         let (pow_address) = get_label_location(pow_);
         let pow = cast(pow_address, felt*);
 
+        // get the leading (big endian) byte of the current_felt
+        // reassign current_felt to the be remainder
         let (current_byte, current_felt) = unsigned_div_rem(current_felt, pow[remaining_shift]);
+        // add byte to returned array
         assert [bytecode] = current_byte;
 
         return load_bytecode(

--- a/src/kakarot/accounts/contract/library.cairo
+++ b/src/kakarot/accounts/contract/library.cairo
@@ -6,6 +6,8 @@
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.math import unsigned_div_rem
+from starkware.cairo.common.registers import get_label_location
 
 // OpenZeppelin dependencies
 from openzeppelin.access.ownable.library import Ownable
@@ -46,7 +48,7 @@ namespace ContractAccount {
         // Initialize access control.
         Ownable.initializer(kakarot_address);
         // Store the bytecode.
-        internal.write_bytecode(0, bytecode_len, bytecode);
+        internal.write_bytecode(0, bytecode_len, bytecode, 0, 16);
         return ();
     }
 
@@ -62,7 +64,14 @@ namespace ContractAccount {
         // Access control check.
         Ownable.assert_only_owner();
         // Recursively store the bytecode.
-        internal.write_bytecode(0, bytecode_len, bytecode);
+        bytecode_len_.write(bytecode_len);
+        internal.write_bytecode(
+            index=0,
+            bytecode_len=bytecode_len,
+            bytecode=bytecode,
+            current_felt=0,
+            remaining_shift=16,
+        );
         return ();
     }
 
@@ -80,7 +89,13 @@ namespace ContractAccount {
         let (bytecode_len) = bytecode_len_.read();
         // Recursively load bytecode into specified memory location.
         let bytecode_: felt* = alloc();
-        internal.load_bytecode(0, bytecode_len, bytecode_);
+        internal.load_bytecode(
+            index=0,
+            bytecode_len=bytecode_len,
+            bytecode=bytecode_,
+            current_felt=0,
+            remaining_shift=0,
+        );
         return (bytecode_len, bytecode_);
     }
 
@@ -142,20 +157,53 @@ namespace ContractAccount {
 
 namespace internal {
     // @notice Store the bytecode of the contract.
-    // @param index: The index in the bytecode.
+    // @param index: The index in the bytecode_stored.
     // @param bytecode_len: The length of the bytecode.
     // @param bytecode: The bytecode of the contract.
     func write_bytecode{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-        index: felt, bytecode_len: felt, bytecode: felt*
+        index: felt, bytecode_len: felt, bytecode: felt*, current_felt: felt, remaining_shift: felt
     ) {
         alloc_locals;
-        if (index == bytecode_len) {
-            bytecode_len_.write(bytecode_len);
+
+        if (bytecode_len == 0) {
+            // end of bytecode case
+            bytecode_.write(index, current_felt);
             return ();
         }
-        bytecode_.write(index, bytecode[index]);
-        write_bytecode(index + 1, bytecode_len, bytecode);
-        return ();
+
+        if (remaining_shift == 0) {
+            // end of packed felt case
+            bytecode_.write(index, current_felt);
+            return write_bytecode(index + 1, bytecode_len, bytecode, 0, 16);
+        }
+
+        let (pow_address) = get_label_location(pow_);
+        let pow = cast(pow_address, felt*);
+
+        let current_felt = pow[remaining_shift] * [bytecode] + current_felt;
+
+        return write_bytecode(
+            index, bytecode_len - 1, bytecode + 1, current_felt, remaining_shift - 1
+        );
+
+        pow_:
+        dw 0;
+        dw 1;
+        dw 2 ** 8;
+        dw 2 ** 16;
+        dw 2 ** 24;
+        dw 2 ** 32;
+        dw 2 ** 40;
+        dw 2 ** 48;
+        dw 2 ** 56;
+        dw 2 ** 64;
+        dw 2 ** 72;
+        dw 2 ** 80;
+        dw 2 ** 88;
+        dw 2 ** 96;
+        dw 2 ** 104;
+        dw 2 ** 112;
+        dw 2 ** 120;
     }
 
     // @notice Load the bytecode of the contract in the specified array.
@@ -167,15 +215,45 @@ namespace internal {
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
-    }(index: felt, bytecode_len: felt, bytecode: felt*) {
+    }(index: felt, bytecode_len: felt, bytecode: felt*, current_felt: felt, remaining_shift: felt) {
         alloc_locals;
-        if (index == bytecode_len) {
+
+        if (bytecode_len == 0) {
             return ();
         }
-        let (value) = bytecode_.read(index);
-        assert [bytecode + index] = value;
 
-        load_bytecode(index + 1, bytecode_len, bytecode);
-        return ();
+        if (remaining_shift == 0) {
+            let (current_felt) = bytecode_.read(index);
+            return load_bytecode(index + 1, bytecode_len, bytecode, current_felt, 16);
+        }
+
+        let (pow_address) = get_label_location(pow_);
+        let pow = cast(pow_address, felt*);
+
+        let (current_byte, current_felt) = unsigned_div_rem(current_felt, pow[remaining_shift]);
+        assert [bytecode] = current_byte;
+
+        return load_bytecode(
+            index, bytecode_len - 1, bytecode + 1, current_felt, remaining_shift - 1
+        );
+
+        pow_:
+        dw 0;
+        dw 1;
+        dw 2 ** 8;
+        dw 2 ** 16;
+        dw 2 ** 24;
+        dw 2 ** 32;
+        dw 2 ** 40;
+        dw 2 ** 48;
+        dw 2 ** 56;
+        dw 2 ** 64;
+        dw 2 ** 72;
+        dw 2 ** 80;
+        dw 2 ** 88;
+        dw 2 ** 96;
+        dw 2 ** 104;
+        dw 2 ** 112;
+        dw 2 ** 120;
     }
 }

--- a/src/kakarot/accounts/contract/library.cairo
+++ b/src/kakarot/accounts/contract/library.cairo
@@ -34,6 +34,8 @@ func storage_(key: Uint256) -> (value: Uint256) {
 func is_initialized_() -> (res: felt) {
 }
 
+const byte_size = 16;
+
 namespace ContractAccount {
     // @notice This function is used to initialize the smart contract account.
     // @param kakarot_address: The address of the Kakarot smart contract.
@@ -48,7 +50,7 @@ namespace ContractAccount {
         // Initialize access control.
         Ownable.initializer(kakarot_address);
         // Store the bytecode.
-        internal.write_bytecode(0, bytecode_len, bytecode, 0, 16);
+        internal.write_bytecode(0, bytecode_len, bytecode, 0, byte_size);
         return ();
     }
 
@@ -70,7 +72,7 @@ namespace ContractAccount {
             bytecode_len=bytecode_len,
             bytecode=bytecode,
             current_felt=0,
-            remaining_shift=16,
+            remaining_shift=byte_size,
         );
         return ();
     }
@@ -156,6 +158,25 @@ namespace ContractAccount {
 }
 
 namespace internal {
+    pow_:
+    dw 0;
+    dw 1;
+    dw 2 ** 8;
+    dw 2 ** 16;
+    dw 2 ** 24;
+    dw 2 ** 32;
+    dw 2 ** 40;
+    dw 2 ** 48;
+    dw 2 ** 56;
+    dw 2 ** 64;
+    dw 2 ** 72;
+    dw 2 ** 80;
+    dw 2 ** 88;
+    dw 2 ** 96;
+    dw 2 ** 104;
+    dw 2 ** 112;
+    dw 2 ** 120;
+
     // @notice Store the bytecode of the contract.
     // @param index: The index in the bytecode_stored.
     // @param bytecode_len: The length of the bytecode.
@@ -174,7 +195,7 @@ namespace internal {
         if (remaining_shift == 0) {
             // end of packed felt case
             bytecode_.write(index, current_felt);
-            return write_bytecode(index + 1, bytecode_len, bytecode, 0, 16);
+            return write_bytecode(index + 1, bytecode_len, bytecode, 0, byte_size);
         }
 
         let (pow_address) = get_label_location(pow_);
@@ -185,25 +206,6 @@ namespace internal {
         return write_bytecode(
             index, bytecode_len - 1, bytecode + 1, current_felt, remaining_shift - 1
         );
-
-        pow_:
-        dw 0;
-        dw 1;
-        dw 2 ** 8;
-        dw 2 ** 16;
-        dw 2 ** 24;
-        dw 2 ** 32;
-        dw 2 ** 40;
-        dw 2 ** 48;
-        dw 2 ** 56;
-        dw 2 ** 64;
-        dw 2 ** 72;
-        dw 2 ** 80;
-        dw 2 ** 88;
-        dw 2 ** 96;
-        dw 2 ** 104;
-        dw 2 ** 112;
-        dw 2 ** 120;
     }
 
     // @notice Load the bytecode of the contract in the specified array.
@@ -224,7 +226,7 @@ namespace internal {
 
         if (remaining_shift == 0) {
             let (current_felt) = bytecode_.read(index);
-            return load_bytecode(index + 1, bytecode_len, bytecode, current_felt, 16);
+            return load_bytecode(index + 1, bytecode_len, bytecode, current_felt, byte_size);
         }
 
         let (pow_address) = get_label_location(pow_);
@@ -236,24 +238,5 @@ namespace internal {
         return load_bytecode(
             index, bytecode_len - 1, bytecode + 1, current_felt, remaining_shift - 1
         );
-
-        pow_:
-        dw 0;
-        dw 1;
-        dw 2 ** 8;
-        dw 2 ** 16;
-        dw 2 ** 24;
-        dw 2 ** 32;
-        dw 2 ** 40;
-        dw 2 ** 48;
-        dw 2 ** 56;
-        dw 2 ** 64;
-        dw 2 ** 72;
-        dw 2 ** 80;
-        dw 2 ** 88;
-        dw 2 ** 96;
-        dw 2 ** 104;
-        dw 2 ** 112;
-        dw 2 ** 120;
     }
 }

--- a/tests/units/test_contract_account.py
+++ b/tests/units/test_contract_account.py
@@ -22,11 +22,13 @@ async def contract_account(starknet: Starknet):
 
 @pytest.mark.asyncio
 class TestContractAccount:
-    async def test_should_store_code(self, contract_account: StarknetContract):
-        bytecode_len = 10
+    @pytest.mark.parametrize("bytecode_len", [0, 15, 16, 17, 30, 31, 32, 33])
+    async def test_should_store_code(
+        self, contract_account: StarknetContract, bytecode_len
+    ):
         bytecode = [random.randint(0, 255) for _ in range(bytecode_len)]
 
         with traceit.context("contract_account"):
             await contract_account.write_bytecode(bytecode).execute(caller_address=1)
-        stored_bytecode = await contract_account.bytecode().call()
-        assert stored_bytecode.result.bytecode == bytecode
+        stored_bytecode = (await contract_account.bytecode().call()).result.bytecode
+        assert stored_bytecode == bytecode


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The Account contract stores the bytecode of the contract as an array of felt, one byte per felt.

Issue Number: #239 

## What is the new behavior?

I have used bytes16 internal felt packing.

## Other information

Is 16 better than 31? I've used this because of the `unsigned_div_rem` but maybe better to use bytes31 and Uint256 div.
May also be better to accept the packed bytecode in the constructor to avoid the cost of doing it in the contract.
Maybe to return packed felt as well and update the other functions accordingly.
This was a fast (and furious 🏁) quick look at the question to have a first estimate of potential gains.
