### PR TITLE
refactor: manipulate decimal number in tests

### DIFF
--- a/tests/integrations/test_zk_evm.py
+++ b/tests/integrations/test_zk_evm.py
@@ -73,28 +73,28 @@ class TestZkEVM:
         )
         with traceit.context(request.node.own_markers[0].name):
 
-            await erc_20.mint(addresses[2], 0x164, caller_address=caller_addresses[1])
+            await erc_20.mint(addresses[2], 356, caller_address=caller_addresses[1])
 
             total_supply = await erc_20.totalSupply()
-            assert total_supply == 0x164
+            assert total_supply == 356
 
             await erc_20.approve(
-                addresses[1], 0xF4240, caller_address=caller_addresses[2]
+                addresses[1], 1000000, caller_address=caller_addresses[2]
             )
 
             allowance = await erc_20.allowance(addresses[2], addresses[1])
-            assert allowance == 0xF4240
+            assert allowance == 1000000
 
             balances_before = [await erc_20.balanceOf(address) for address in addresses]
 
             await erc_20.transferFrom(
-                addresses[2], addresses[1], 0xA, caller_address=caller_addresses[1]
+                addresses[2], addresses[1], 10, caller_address=caller_addresses[1]
             )
             balances_after = [await erc_20.balanceOf(address) for address in addresses]
 
             assert balances_after[0] - balances_before[0] == 0
-            assert balances_after[1] - balances_before[1] == 0xA
-            assert balances_after[2] - balances_before[2] == -0xA
+            assert balances_after[1] - balances_before[1] == 10
+            assert balances_after[2] - balances_before[2] == -10
             assert balances_after[3] - balances_before[3] == 0
 
             balances_before = balances_after
@@ -103,7 +103,7 @@ class TestZkEVM:
             balances_after = [await erc_20.balanceOf(address) for address in addresses]
 
             assert balances_after[0] - balances_before[0] == 0
-            assert balances_after[1] - balances_before[1] == -0x5
+            assert balances_after[1] - balances_before[1] == -5
             assert balances_after[2] - balances_before[2] == 0
-            assert balances_after[3] - balances_before[3] == 0x5
+            assert balances_after[3] - balances_before[3] == 5
         kakarot.state = state


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, and submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
in [erc20 integration test](https://github.com/sayajin-labs/kakarot/blob/main/tests/integrations/test_zk_evm.py#L76)
`await erc_20.mint(addresses[2], 0x164, caller_address=caller_addresses[1])`
we could improve readability using the '356' decimal value instead of 0x164

Issue Number: #273 

## What is the new behavior?
- the `0x164` was replaced with `356`

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
