### PR TITLE
Display detailed diff in CI + fix tests resources used in diff check

### DIFF
--- a/scripts/check_resources.py
+++ b/scripts/check_resources.py
@@ -1,3 +1,4 @@
+#%% Imports
 import io
 import logging
 import os
@@ -17,6 +18,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+#%% main
 def main():
     #%% Script constants
     coverage_dir = Path("coverage")
@@ -77,6 +79,8 @@ def main():
             )
         )
         .drop_duplicates(["head_branch", "id"])
+        .loc[lambda df: ~df.contract_name.str.contains("test")]  # type: ignore
+        .loc[lambda df: ~df.function_name.str.contains("test")]
     )
     resources_summary = (
         all_resources.drop(["contract_name", "function_name", "args", "kwargs"], axis=1)


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When the check-resources fails, the logs don't display a detailed list of changed tests. This slow down debugging and require the team to be able to efficiently parse the files to get this info.

Furthermore, the complexity of the test functions is also included in the resources summary.

## What is the new behavior?

A detailed diff table is printed out if resources change:

```
                              n_steps  n_memory_holes  range_check_builtin  bitwise_builtin  pedersen_builtin
contract_name function_name                                                                                  
ERC20         allowance      -82668.0        -34800.0                663.0              0.0           -3315.0
              approve        -82668.0        -34800.0                663.0              0.0           -3315.0
              balanceOf      -82668.0        -34800.0                663.0              0.0           -3315.0
```

Furthermore, the contracts and functions including `test` in theire names are filtered out for the metrics.
