### PR TITLE
Add tests for bytes_i_to_uint256 method and fixes it for 16 bytes sequences

### DIFF
--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -51,17 +51,17 @@ namespace Helpers {
             assert is_sequence_32_bytes_or_less = 1;
         }
 
-        let is_sequence_15_bytes_or_less = is_le(i, 15);
+        let is_sequence_16_bytes_or_less = is_le(i, 16);
 
-        // 1 - 15 bytes
-        if (is_sequence_15_bytes_or_less == TRUE) {
+        // 1 - 16 bytes
+        if (is_sequence_16_bytes_or_less == TRUE) {
             let (low) = compute_half_uint256(val=val, i=i, res=0);
             let res = Uint256(low=low, high=0);
 
             return res;
         }
 
-        // 16 - 32 bytes
+        // 17 - 32 bytes
         let (low) = compute_half_uint256(val=val + i - 16, i=16, res=0);
         let (high) = compute_half_uint256(val=val, i=i - 16, res=0);
         let res = Uint256(low=low, high=high);

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -16,7 +16,7 @@ from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.pow import pow
 from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.registers import get_label_location
-from starkware.cairo.common.bool import TRUE, FALSE
+from starkware.cairo.common.bool import FALSE
 
 // @title Helper Functions
 // @notice This file contains a selection of helper function that simplify tasks such as type conversion and bit manipulation
@@ -54,7 +54,7 @@ namespace Helpers {
         let is_sequence_16_bytes_or_less = is_le(i, 16);
 
         // 1 - 16 bytes
-        if (is_sequence_16_bytes_or_less == TRUE) {
+        if (is_sequence_16_bytes_or_less != FALSE) {
             let (low) = compute_half_uint256(val=val, i=i, res=0);
             let res = Uint256(low=low, high=0);
 

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -16,7 +16,7 @@ from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.pow import pow
 from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.registers import get_label_location
-from starkware.cairo.common.bool import FALSE
+from starkware.cairo.common.bool import TRUE, FALSE
 
 // @title Helper Functions
 // @notice This file contains a selection of helper function that simplify tasks such as type conversion and bit manipulation
@@ -41,44 +41,31 @@ namespace Helpers {
     }
     // @notice This function is used to convert a sequence of i bytes to Uint256.
     // @param val: pointer to the first byte.
-    // @param i: pointer to the first byte.
+    // @param i: sequence size.
     // @return res: Uint256 representation of the given input in bytes.
     func bytes_i_to_uint256{range_check_ptr}(val: felt*, i: felt) -> Uint256 {
         alloc_locals;
-        local new_i: felt;
-        local new_val: felt*;
-        local high: felt;
-        local low: felt;
 
-        // Check if i is lower to 32
-        let is_le32 = is_le(i, 32);
+        let is_sequence_32_bytes_or_less = is_le(i, 32);
         with_attr error_message("number must be shorter than 32 bytes") {
-            assert is_le32 = 1;
+            assert is_sequence_32_bytes_or_less = 1;
         }
 
-        let is_16_le_i = is_le(16, i);
-        if (is_16_le_i != FALSE) {
-            assert new_val = val + i - 16;
-            new_i = 16;
-            let (high_temp) = compute_half_uint256(val=val, i=i - 16, res=0);
-            high = high_temp;
-            tempvar range_check_ptr = range_check_ptr;
-        } else {
-            new_val = val;
-            new_i = i;
-            high = 0;
-            tempvar range_check_ptr = range_check_ptr;
+        let is_sequence_15_bytes_or_less = is_le(i, 15);
+
+        // 1 - 15 bytes
+        if (is_sequence_15_bytes_or_less == TRUE) {
+            let (low) = compute_half_uint256(val=val, i=i, res=0);
+            let res = Uint256(low=low, high=0);
+
+            return res;
         }
 
-        let is_i_le_16 = is_le(new_i, 16);
-
-        if (is_i_le_16 != FALSE) {
-            let (low_temp) = compute_half_uint256(val=new_val, i=new_i, res=0);
-            low = low_temp;
-        } else {
-            low = 0;
-        }
+        // 16 - 32 bytes
+        let (low) = compute_half_uint256(val=val + i - 16, i=16, res=0);
+        let (high) = compute_half_uint256(val=val, i=i - 16, res=0);
         let res = Uint256(low=low, high=high);
+
         return res;
     }
 

--- a/tests/cairo_files/instructions/test_push_operations.cairo
+++ b/tests/cairo_files/instructions/test_push_operations.cairo
@@ -197,6 +197,18 @@ func test__exec_push15_should_add_15_byte_to_stack{
 }
 
 @external
+func test__exec_push16_should_add_16_byte_to_stack{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() {
+    alloc_locals;
+    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_bytecode(17, 0xFF);
+    let result = PushOperations.exec_push16(ctx);
+    TestHelpers.assert_stack_last_element_contains_uint256(result.stack, Uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF, 0));
+
+    return ();
+}
+
+@external
 func test__exec_push17_should_add_17_byte_to_stack{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }() {

--- a/tests/cairo_files/test_utils.cairo
+++ b/tests/cairo_files/test_utils.cairo
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+
+%lang starknet
+
+// Starkware dependencies
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
+from starkware.cairo.common.uint256 import Uint256, assert_uint256_eq
+
+// Local dependencies
+from utils.utils import Helpers
+
+from tests.utils.utils import TestHelpers
+
+@external
+func test__bytes_i_to_uint256{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() {
+    alloc_locals;
+
+    let (bytecode) = alloc();
+    assert bytecode[0] = 0x01;
+    assert bytecode[1] = 0x02;
+
+    let uint256 = Helpers.bytes_i_to_uint256(bytecode, 1);
+
+    assert_uint256_eq(
+        uint256,
+        Uint256(0x01, 0)
+    );
+
+    let uint256 = Helpers.bytes_i_to_uint256(bytecode, 2);
+
+    assert_uint256_eq(
+        uint256,
+        Uint256(0x0102, 0)
+    );
+
+    let (bytecode) = alloc();
+    TestHelpers._fill_bytecode_with_values(bytecode, 20, 0xFF);
+    let uint256 = Helpers.bytes_i_to_uint256(bytecode, 20);
+
+    assert_uint256_eq(
+        uint256,
+        Uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF, 0xFFFFFFFF)
+    );
+
+    return ();
+}

--- a/tests/cairo_files/test_utils.cairo
+++ b/tests/cairo_files/test_utils.cairo
@@ -45,5 +45,14 @@ func test__bytes_i_to_uint256{
         Uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF, 0xFFFFFFFF)
     );
 
+    let (bytecode) = alloc();
+    TestHelpers._fill_bytecode_with_values(bytecode, 16, 0xFF);
+    let uint256 = Helpers.bytes_i_to_uint256(bytecode, 16);
+
+    assert_uint256_eq(
+        uint256,
+        Uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF, 0)
+    );
+
     return ();
 }

--- a/tests/units/instructions/test_push_operations.py
+++ b/tests/units/instructions/test_push_operations.py
@@ -59,6 +59,9 @@ class TestPushOperations:
     async def test__exec_push15_should_add_15_byte_to_stack(self, push_operations):
         await push_operations.test__exec_push15_should_add_15_byte_to_stack().call()
 
+    async def test__exec_push16_should_add_16_byte_to_stack(self, push_operations):
+        await push_operations.test__exec_push16_should_add_16_byte_to_stack().call()
+
     async def test__exec_push17_should_add_17_byte_to_stack(self, push_operations):
         await push_operations.test__exec_push17_should_add_17_byte_to_stack().call()
 

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -1,0 +1,19 @@
+import re
+
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def stack(starknet):
+    return await starknet.deploy(
+        source="./tests/cairo_files/test_utils.cairo",
+        cairo_path=["src"],
+        disable_hint_validation=False,
+    )
+
+
+@pytest.mark.asyncio
+class TestStack:
+    async def test__bytes_i_to_uint256(self, stack):
+        await stack.test__bytes_i_to_uint256().call()


### PR DESCRIPTION
The bytes_i_to_uint256 was bugged with sequences of exactly 16 bytes.

Issue was caused by a [lower_or_equal]([`main...matthieuauger:kakarot:fix-bytes_to_uint256?expand=1`#diff-7125bfc485](https://github.com/sayajin-labs/kakarot/compare/main...matthieuauger:kakarot:fix-bytes_to_uint256?expand=1#diff-7125bfc4851cb1b3a82161b692339e996956180ec6a010a5f5dd7504ee97cef9)L59) used instead of a strict lower.

- First commit of the PR consists of adding tests for the function.
- Second commit is a refactoring of the function, simplying its implementation and improving naming
- Third commit is the actual bugfix
- Fourth commit is the re-enablement of the exec_push16 test that was blocked because of this bug

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): tests

## What is the current behavior?

Fixed #333 