### PR TITLE
feat: use gas in CALLs opcodes #349

### DIFF
--- a/src/kakarot/execution_context.cairo
+++ b/src/kakarot/execution_context.cairo
@@ -131,6 +131,7 @@ namespace ExecutionContext {
         bitwise_ptr: BitwiseBuiltin*,
     }(
         address: felt,
+        gas_limit: felt,
         calldata_len: felt,
         calldata: felt*,
         value: felt,
@@ -168,8 +169,7 @@ namespace ExecutionContext {
             stack=stack,
             memory=memory,
             gas_used=0,
-            // TODO: Add support for gas limit
-            gas_limit=0,
+            gas_limit=gas_limit,
             intrinsic_gas_cost=0,
             starknet_contract_address=starknet_contract_address,
             evm_contract_address=address,

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -212,11 +212,14 @@ namespace SystemOperations {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
+        alloc_locals;
         let (ctx, call_args) = CallHelper.prepare_args(ctx=ctx, with_value=1);
-
-        // TODO: use gas_limit when init_at_address is updated
+        let remaining_gas = ctx.gas_limit - ctx.gas_used;
+        let (max_allowed_gas, _) = Helpers.div_rem(remaining_gas, 64);
+        let gas_limit = Helpers.min(call_args.gas, max_allowed_gas);
         let sub_ctx = ExecutionContext.init_at_address(
             address=call_args.address,
+            gas_limit=gas_limit,
             calldata_len=call_args.args_size,
             calldata=call_args.calldata,
             value=call_args.value,
@@ -242,11 +245,16 @@ namespace SystemOperations {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
+        alloc_locals;
         let (ctx, call_args) = CallHelper.prepare_args(ctx=ctx, with_value=0);
 
-        // TODO: use gas_limit when init_at_address is updated
+        let remaining_gas = ctx.gas_limit - ctx.gas_used;
+        let (max_allowed_gas, _) = Helpers.div_rem(remaining_gas, 64);
+        let gas_limit = Helpers.min(call_args.gas, max_allowed_gas);
+
         let sub_ctx = ExecutionContext.init_at_address(
             address=call_args.address,
+            gas_limit=gas_limit,
             calldata_len=call_args.args_size,
             calldata=call_args.calldata,
             value=call_args.value,

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -212,14 +212,11 @@ namespace SystemOperations {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
-        alloc_locals;
         let (ctx, call_args) = CallHelper.prepare_args(ctx=ctx, with_value=1);
-        let remaining_gas = ctx.gas_limit - ctx.gas_used;
-        let (max_allowed_gas, _) = Helpers.div_rem(remaining_gas, 64);
-        let gas_limit = Helpers.min(call_args.gas, max_allowed_gas);
+
         let sub_ctx = ExecutionContext.init_at_address(
             address=call_args.address,
-            gas_limit=gas_limit,
+            gas_limit=call_args.gas,
             calldata_len=call_args.args_size,
             calldata=call_args.calldata,
             value=call_args.value,
@@ -245,16 +242,11 @@ namespace SystemOperations {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
-        alloc_locals;
         let (ctx, call_args) = CallHelper.prepare_args(ctx=ctx, with_value=0);
-
-        let remaining_gas = ctx.gas_limit - ctx.gas_used;
-        let (max_allowed_gas, _) = Helpers.div_rem(remaining_gas, 64);
-        let gas_limit = Helpers.min(call_args.gas, max_allowed_gas);
 
         let sub_ctx = ExecutionContext.init_at_address(
             address=call_args.address,
-            gas_limit=gas_limit,
+            gas_limit=call_args.gas,
             calldata_len=call_args.args_size,
             calldata=call_args.calldata,
             value=call_args.value,
@@ -357,8 +349,12 @@ namespace CallHelper {
             self=ctx.memory, element_len=args_size, element=calldata, offset=args_offset
         );
 
+        let remaining_gas = ctx.gas_limit - ctx.gas_used;
+        let (max_allowed_gas, _) = Helpers.div_rem(remaining_gas, 64);
+        let gas_limit = Helpers.min(gas, max_allowed_gas);
+
         let call_args = CallArgs(
-            gas=gas,
+            gas=gas_limit,
             address=address,
             value=value,
             args_size=args_size,

--- a/src/kakarot/interfaces/interfaces.cairo
+++ b/src/kakarot/interfaces/interfaces.cairo
@@ -47,7 +47,9 @@ namespace IKakarot {
     ) {
     }
 
-    func execute_at_address(address: felt, value: felt, gas_limit: felt, calldata_len: felt, calldata: felt*) {
+    func execute_at_address(
+        address: felt, value: felt, gas_limit: felt, calldata_len: felt, calldata: felt*
+    ) {
     }
 
     func set_account_registry(registry_address_: felt) {

--- a/src/kakarot/interfaces/interfaces.cairo
+++ b/src/kakarot/interfaces/interfaces.cairo
@@ -47,7 +47,7 @@ namespace IKakarot {
     ) {
     }
 
-    func execute_at_address(address: felt, value: felt, calldata_len: felt, calldata: felt*) {
+    func execute_at_address(address: felt, value: felt, gas_limit: felt, calldata_len: felt, calldata: felt*) {
     }
 
     func set_account_registry(registry_address_: felt) {

--- a/src/kakarot/kakarot.cairo
+++ b/src/kakarot/kakarot.cairo
@@ -73,7 +73,7 @@ func execute{
 // @dev reads the bytecode content of an contract account and then executes it
 // @param address The address of the contract whose bytecode will be executed
 // @param value The deposited value by the instruction/transaction responsible for this execution
-// @param gas_limit Max gas the transaction can use 
+// @param gas_limit Max gas the transaction can use
 // @param calldata_len The calldata length
 // @param calldata The calldata which contains the entry point and method parameters
 // @return stack_len The length of the stack
@@ -99,7 +99,11 @@ func execute_at_address{
 ) {
     alloc_locals;
     let summary = Kakarot.execute_at_address(
-        address=address, calldata_len=calldata_len, calldata=calldata, value=value, gas_limit=gas_limit
+        address=address,
+        calldata_len=calldata_len,
+        calldata=calldata,
+        value=value,
+        gas_limit=gas_limit,
     );
     let memory_accesses_len = summary.memory.squashed_end - summary.memory.squashed_start;
     let stack_accesses_len = summary.stack.squashed_end - summary.stack.squashed_start;

--- a/src/kakarot/kakarot.cairo
+++ b/src/kakarot/kakarot.cairo
@@ -73,6 +73,7 @@ func execute{
 // @dev reads the bytecode content of an contract account and then executes it
 // @param address The address of the contract whose bytecode will be executed
 // @param value The deposited value by the instruction/transaction responsible for this execution
+// @param gas_limit Max gas the transaction can use 
 // @param calldata_len The calldata length
 // @param calldata The calldata which contains the entry point and method parameters
 // @return stack_len The length of the stack
@@ -84,7 +85,7 @@ func execute{
 @external
 func execute_at_address{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}(address: felt, value: felt, calldata_len: felt, calldata: felt*) -> (
+}(address: felt, value: felt, gas_limit: felt, calldata_len: felt, calldata: felt*) -> (
     stack_accesses_len: felt,
     stack_accesses: felt*,
     stack_len: felt,
@@ -98,7 +99,7 @@ func execute_at_address{
 ) {
     alloc_locals;
     let summary = Kakarot.execute_at_address(
-        address=address, calldata_len=calldata_len, calldata=calldata, value=value
+        address=address, calldata_len=calldata_len, calldata=calldata, value=value, gas_limit=gas_limit
     );
     let memory_accesses_len = summary.memory.squashed_end - summary.memory.squashed_start;
     let stack_accesses_len = summary.stack.squashed_end - summary.stack.squashed_start;

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -76,6 +76,7 @@ namespace Kakarot {
     // @dev reads the bytecode content of an EVM contract and then executes it
     // @param address The address of the contract whose bytecode will be executed
     // @param calldata The calldata which contains the entry point and method parameters
+    // @param gas_limit Max gas the transaction can use
     // @return The pointer to the updated execution context.
     func execute_at_address{
         syscall_ptr: felt*,
@@ -83,7 +84,7 @@ namespace Kakarot {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(
-        address: felt, calldata_len: felt, calldata: felt*, value: felt
+        address: felt, calldata_len: felt, calldata: felt*, value: felt, gas_limit: felt
     ) -> ExecutionContext.Summary* {
         alloc_locals;
 
@@ -92,6 +93,7 @@ namespace Kakarot {
         let return_data: felt* = alloc();
         let ctx: model.ExecutionContext* = ExecutionContext.init_at_address(
             address=address,
+            gas_limit=gas_limit,
             calldata_len=calldata_len,
             calldata=calldata,
             value=value,

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -480,8 +480,8 @@ namespace Helpers {
     }
 
     // @notice Returns the min value between a and b
-    func min{range_check_ptr}(a:felt, b: felt) -> felt {
-        if(is_le(a, b) == 0) {
+    func min{range_check_ptr}(a: felt, b: felt) -> felt {
+        if (is_le(a, b) == 0) {
             return b;
         } else {
             return a;

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -481,10 +481,10 @@ namespace Helpers {
 
     // @notice Returns the min value between a and b
     func min{range_check_ptr}(a:felt, b: felt) -> felt {
-        if(is_le(a, b) == 1) {
-            return a;
-        } else {
+        if(is_le(a, b) == 0) {
             return b;
+        } else {
+            return a;
         }
     }
 }

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -478,4 +478,13 @@ namespace Helpers {
         let (q, _) = unsigned_div_rem(bytes_len + 31, 32);
         return q * 32;
     }
+
+    // @notice Returns the min value between a and b
+    func min{range_check_ptr}(a:felt, b: felt) -> felt {
+        if(is_le(a, b) == 1) {
+            return a;
+        } else {
+            return b;
+        }
+    }
 }

--- a/tests/integration/helpers/wrap_kakarot.py
+++ b/tests/integration/helpers/wrap_kakarot.py
@@ -30,6 +30,7 @@ def wrap_for_kakarot(
                 call = kakarot.execute_at_address(
                     address=evm_contract_address,
                     value=0,
+                    gas_limit=1000000,
                     calldata=hex_string_to_bytes_array(
                         contract.encodeABI(fun, args, kwargs)
                     ),
@@ -46,6 +47,7 @@ def wrap_for_kakarot(
                 call = kakarot.execute_at_address(
                     address=evm_contract_address,
                     value=value,
+                    gas_limit=1000000,
                     calldata=hex_string_to_bytes_array(
                         contract.encodeABI(fun, args, kwargs)
                     ),

--- a/tests/integration/helpers/wrap_kakarot.py
+++ b/tests/integration/helpers/wrap_kakarot.py
@@ -26,11 +26,17 @@ def wrap_for_kakarot(
 
         async def _wrapped(contract, *args, **kwargs):
             abi = contract.get_function_by_name(fun).abi
+            if "gas_limit" in kwargs:
+                gas_limit=kwargs["gas_limit"]
+                del kwargs["gas_limit"]
+            else:
+                gas_limit=1000000
+
             if abi["stateMutability"] == "view":
                 call = kakarot.execute_at_address(
                     address=evm_contract_address,
                     value=0,
-                    gas_limit=1000000,
+                    gas_limit=gas_limit,
                     calldata=hex_string_to_bytes_array(
                         contract.encodeABI(fun, args, kwargs)
                     ),

--- a/tests/integration/helpers/wrap_kakarot.py
+++ b/tests/integration/helpers/wrap_kakarot.py
@@ -27,10 +27,10 @@ def wrap_for_kakarot(
         async def _wrapped(contract, *args, **kwargs):
             abi = contract.get_function_by_name(fun).abi
             if "gas_limit" in kwargs:
-                gas_limit=kwargs["gas_limit"]
+                gas_limit = kwargs["gas_limit"]
                 del kwargs["gas_limit"]
             else:
-                gas_limit=1000000
+                gas_limit = 1000000
 
             if abi["stateMutability"] == "view":
                 call = kakarot.execute_at_address(

--- a/tests/unit/src/kakarot/instructions/test_comparison_operations.cairo
+++ b/tests/unit/src/kakarot/instructions/test_comparison_operations.cairo
@@ -459,7 +459,7 @@ func test__exec_or__should_pop_0_and_1_and_push_0xCD__when_0_is_0x89_and_1_is_0x
     assert len = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
     assert index0 = Uint256(0xCD, 0);
-    return();    
+    return ();
 }
 
 @external
@@ -483,7 +483,7 @@ func test__exec_xor__should_pop_0_and_1_and_push_0__when_0_and_1_are_true{
     let len: felt = result.stack.len_16bytes / 2;
     assert len = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0,0);
+    assert index0 = Uint256(0, 0);
     return ();
 }
 
@@ -508,7 +508,7 @@ func test__exec_xor__should_pop_0_and_1_and_push_0__when_0_and_1_are_not_true{
     let len: felt = result.stack.len_16bytes / 2;
     assert len = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0,0);
+    assert index0 = Uint256(0, 0);
     return ();
 }
 
@@ -533,7 +533,7 @@ func test__exec_xor__should_pop_0_and_1_and_push_1__when_0_is_true_and_1_is_not_
     let len: felt = result.stack.len_16bytes / 2;
     assert len = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1,0);
+    assert index0 = Uint256(1, 0);
     return ();
 }
 
@@ -558,7 +558,7 @@ func test__exec_xor__should_pop_0_and_1_and_push_1__when_0_is_not_true_and_1_is_
     let len: felt = result.stack.len_16bytes / 2;
     assert len = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1,0);
+    assert index0 = Uint256(1, 0);
     return ();
 }
 
@@ -597,7 +597,7 @@ func test__exec_byte__should_pop_0_and_1_and_push_0__when_0_is_less_than_16_byte
     let stack: model.Stack* = Stack.init();
 
     let stack: model.Stack* = Stack.push(stack, Uint256(0xFFEEDDCCBBAA998877665544332211, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(23,0));
+    let stack: model.Stack* = Stack.push(stack, Uint256(23, 0));
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -622,7 +622,7 @@ func test__exec_byte__should_pop_0_and_1_and_push_0__when_0_is_larger_than_16_by
     let stack: model.Stack* = Stack.init();
 
     let stack: model.Stack* = Stack.push(stack, Uint256(0, 0x123456789ABCDEF0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(8,0));
+    let stack: model.Stack* = Stack.push(stack, Uint256(8, 0));
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When

--- a/tests/unit/src/kakarot/instructions/test_comparison_operations.py
+++ b/tests/unit/src/kakarot/instructions/test_comparison_operations.py
@@ -88,7 +88,7 @@ class TestComparisonOperations:
         self, comparison_operations
     ):
         await comparison_operations.test__exec_and__should_pop_0_and_1_and_push_0x89__when_0_is_0xC9_and_1_is_0xBD().call()
-    
+
     async def test__exec_or__should_pop_0_and_1_and_push_0__when_0_or_1_are_not_true(
         self, comparison_operations
     ):
@@ -103,7 +103,7 @@ class TestComparisonOperations:
         self, comparison_operations
     ):
         await comparison_operations.test__exec_or__should_pop_0_and_1_and_push_0xCD__when_0_is_0x89_and_1_is_0xC5().call()
-    
+
     async def test__exec_xor__should_pop_0_and_1_and_push_0__when_0_and_1_are_true(
         self, comparison_operations
     ):
@@ -128,17 +128,17 @@ class TestComparisonOperations:
         self, comparison_operations
     ):
         await comparison_operations.test__exec_xor__should_pop_0_and_1_and_push_0x64__when_0_is_0xB9_and_1_is_0xDD().call()
-    
+
     async def test__exec_byte__should_pop_0_and_1_and_push_0__when_0_is_less_than_16_bytes_and_1_is_23(
         self, comparison_operations
     ):
         await comparison_operations.test__exec_byte__should_pop_0_and_1_and_push_0__when_0_is_less_than_16_bytes_and_1_is_23().call()
-    
+
     async def test__exec_byte__should_pop_0_and_1_and_push_0__when_0_is_larger_than_16_bytes_and_1_is_8(
         self, comparison_operations
     ):
         await comparison_operations.test__exec_byte__should_pop_0_and_1_and_push_0__when_0_is_larger_than_16_bytes_and_1_is_8().call()
-    
+
     async def test__exec_shl__should_pop_0_and_1_and_push_left_shift(
         self, comparison_operations
     ):

--- a/tests/unit/src/kakarot/instructions/test_system_operations.cairo
+++ b/tests/unit/src/kakarot/instructions/test_system_operations.cairo
@@ -6,7 +6,7 @@
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.uint256 import Uint256
-from starkware.cairo.common.math import split_felt, assert_not_zero
+from starkware.cairo.common.math import split_felt, assert_not_zero, assert_le_felt
 
 // Local dependencies
 from kakarot.accounts.contract.library import ContractAccount
@@ -61,7 +61,7 @@ func test__exec_call__should_return_a_new_context_based_on_calling_ctx_stack{
 
     // Fill the stack with input data
     let stack: model.Stack* = Stack.init();
-    let gas = Uint256(0, 0);
+    let gas = Helpers.to_uint256(Constants.TRANSACTION_GAS_LIMIT);
     let (address_high, address_low) = split_felt(evm_contract_address);
     let address = Uint256(address_low, address_high);
     tempvar value = Uint256(2, 0);
@@ -102,7 +102,8 @@ func test__exec_call__should_return_a_new_context_based_on_calling_ctx_stack{
     assert sub_ctx.return_data_len = ret_size.low;
     assert [sub_ctx.return_data] = ret_offset.low;
     assert sub_ctx.gas_used = 0;
-    assert sub_ctx.gas_limit = 0;
+    let (gas_felt, _) = Helpers.div_rem(Constants.TRANSACTION_GAS_LIMIT, 64);
+    assert_le_felt(sub_ctx.gas_limit, gas_felt);
     assert sub_ctx.intrinsic_gas_cost = 0;
     assert sub_ctx.starknet_contract_address = starknet_contract_address;
     assert sub_ctx.evm_contract_address = evm_contract_address;
@@ -137,7 +138,7 @@ func test__exec_callcode__should_return_a_new_context_based_on_calling_ctx_stack
 
     // Fill the stack with input data
     let stack: model.Stack* = Stack.init();
-    let gas = Uint256(0, 0);
+    let gas = Helpers.to_uint256(Constants.TRANSACTION_GAS_LIMIT);
     let (address_high, address_low) = split_felt(evm_contract_address);
     let address = Uint256(address_low, address_high);
     tempvar value = Uint256(2, 0);
@@ -178,7 +179,8 @@ func test__exec_callcode__should_return_a_new_context_based_on_calling_ctx_stack
     assert sub_ctx.return_data_len = ret_size.low;
     assert [sub_ctx.return_data] = ret_offset.low;
     assert sub_ctx.gas_used = 0;
-    assert sub_ctx.gas_limit = 0;
+    let (gas_felt, _) = Helpers.div_rem(Constants.TRANSACTION_GAS_LIMIT, 64);
+    assert_le_felt(sub_ctx.gas_limit, gas_felt);
     assert sub_ctx.intrinsic_gas_cost = 0;
     assert sub_ctx.starknet_contract_address = ctx.starknet_contract_address;
     assert sub_ctx.evm_contract_address = ctx.evm_contract_address;
@@ -213,7 +215,7 @@ func test__exec_staticcall__should_return_a_new_context_based_on_calling_ctx_sta
 
     // Fill the stack with input data
     let stack: model.Stack* = Stack.init();
-    let gas = Uint256(0, 0);
+    let gas = Helpers.to_uint256(Constants.TRANSACTION_GAS_LIMIT);
     let (address_high, address_low) = split_felt(evm_contract_address);
     let address = Uint256(address_low, address_high);
     let args_offset = Uint256(3, 0);
@@ -252,7 +254,8 @@ func test__exec_staticcall__should_return_a_new_context_based_on_calling_ctx_sta
     assert sub_ctx.return_data_len = ret_size.low;
     assert [sub_ctx.return_data] = ret_offset.low;
     assert sub_ctx.gas_used = 0;
-    assert sub_ctx.gas_limit = 0;
+    let (gas_felt, _) = Helpers.div_rem(Constants.TRANSACTION_GAS_LIMIT, 64);
+    assert_le_felt(sub_ctx.gas_limit, gas_felt);
     assert sub_ctx.intrinsic_gas_cost = 0;
     assert sub_ctx.starknet_contract_address = starknet_contract_address;
     assert sub_ctx.evm_contract_address = evm_contract_address;
@@ -287,7 +290,7 @@ func test__exec_delegatecall__should_return_a_new_context_based_on_calling_ctx_s
 
     // Fill the stack with input data
     let stack: model.Stack* = Stack.init();
-    let gas = Uint256(0, 0);
+    let gas = Helpers.to_uint256(Constants.TRANSACTION_GAS_LIMIT);
     let (address_high, address_low) = split_felt(evm_contract_address);
     let address = Uint256(address_low, address_high);
     let args_offset = Uint256(3, 0);
@@ -326,7 +329,8 @@ func test__exec_delegatecall__should_return_a_new_context_based_on_calling_ctx_s
     assert sub_ctx.return_data_len = ret_size.low;
     assert [sub_ctx.return_data] = ret_offset.low;
     assert sub_ctx.gas_used = 0;
-    assert sub_ctx.gas_limit = 0;
+    let (gas_felt, _) = Helpers.div_rem(Constants.TRANSACTION_GAS_LIMIT, 64);
+    assert_le_felt(sub_ctx.gas_limit, gas_felt);
     assert sub_ctx.intrinsic_gas_cost = 0;
     assert sub_ctx.starknet_contract_address = ctx.starknet_contract_address;
     assert sub_ctx.evm_contract_address = ctx.evm_contract_address;

--- a/tests/unit/src/kakarot/instructions/test_system_operations.cairo
+++ b/tests/unit/src/kakarot/instructions/test_system_operations.cairo
@@ -6,7 +6,7 @@
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.uint256 import Uint256
-from starkware.cairo.common.math import split_felt, assert_not_zero, assert_le_felt
+from starkware.cairo.common.math import split_felt, assert_not_zero, assert_le
 
 // Local dependencies
 from kakarot.accounts.contract.library import ContractAccount
@@ -103,7 +103,7 @@ func test__exec_call__should_return_a_new_context_based_on_calling_ctx_stack{
     assert [sub_ctx.return_data] = ret_offset.low;
     assert sub_ctx.gas_used = 0;
     let (gas_felt, _) = Helpers.div_rem(Constants.TRANSACTION_GAS_LIMIT, 64);
-    assert_le_felt(sub_ctx.gas_limit, gas_felt);
+    assert_le(sub_ctx.gas_limit, gas_felt);
     assert sub_ctx.intrinsic_gas_cost = 0;
     assert sub_ctx.starknet_contract_address = starknet_contract_address;
     assert sub_ctx.evm_contract_address = evm_contract_address;
@@ -180,7 +180,7 @@ func test__exec_callcode__should_return_a_new_context_based_on_calling_ctx_stack
     assert [sub_ctx.return_data] = ret_offset.low;
     assert sub_ctx.gas_used = 0;
     let (gas_felt, _) = Helpers.div_rem(Constants.TRANSACTION_GAS_LIMIT, 64);
-    assert_le_felt(sub_ctx.gas_limit, gas_felt);
+    assert_le(sub_ctx.gas_limit, gas_felt);
     assert sub_ctx.intrinsic_gas_cost = 0;
     assert sub_ctx.starknet_contract_address = ctx.starknet_contract_address;
     assert sub_ctx.evm_contract_address = ctx.evm_contract_address;
@@ -255,7 +255,7 @@ func test__exec_staticcall__should_return_a_new_context_based_on_calling_ctx_sta
     assert [sub_ctx.return_data] = ret_offset.low;
     assert sub_ctx.gas_used = 0;
     let (gas_felt, _) = Helpers.div_rem(Constants.TRANSACTION_GAS_LIMIT, 64);
-    assert_le_felt(sub_ctx.gas_limit, gas_felt);
+    assert_le(sub_ctx.gas_limit, gas_felt);
     assert sub_ctx.intrinsic_gas_cost = 0;
     assert sub_ctx.starknet_contract_address = starknet_contract_address;
     assert sub_ctx.evm_contract_address = evm_contract_address;
@@ -330,7 +330,7 @@ func test__exec_delegatecall__should_return_a_new_context_based_on_calling_ctx_s
     assert [sub_ctx.return_data] = ret_offset.low;
     assert sub_ctx.gas_used = 0;
     let (gas_felt, _) = Helpers.div_rem(Constants.TRANSACTION_GAS_LIMIT, 64);
-    assert_le_felt(sub_ctx.gas_limit, gas_felt);
+    assert_le(sub_ctx.gas_limit, gas_felt);
     assert sub_ctx.intrinsic_gas_cost = 0;
     assert sub_ctx.starknet_contract_address = ctx.starknet_contract_address;
     assert sub_ctx.evm_contract_address = ctx.evm_contract_address;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`gas_limit` is passed as `0` to the sub contexts.

Resolves #[349](https://github.com/sayajin-labs/kakarot/issues/349)

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds `gas_limit` param to `execution_context.init_at_address()`, `kakarot.execute_at_address()`
- Limits the gas passed to sub-contexts to `min(remaining_gas, remaining_gas/64)`


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
