### PR TITLE
docs: add an estimate of time spent for PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,4 +30,7 @@ Resolves #<Issue number>
 
 ## Other information
 
+<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->
+Time spent on this PR:  
+
 <!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


### PR DESCRIPTION
add an estimate of time spent for PRs so that contributors may help maintainers understand:
- how much time they spend on kakarot
- how they can help reduce friction / misunderstandings
- how they can help contributors