### PR TITLE
Disable alt-text-required for markdown files

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,7 @@
 {
   "MD033": false,
   "MD041": false,
+  "MD045": false,
   "MD013": {
     "code_blocks": false
   }

--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ Here is the execution trace of the program on Kakarot:
 
 ## Getting started
 
-To contribute, please check out [the contribution guide](./docs/CONTRIBUTING.md).
+To contribute, please check out
+[the contribution guide](./docs/CONTRIBUTING.md).
 
 ```bash
 # install poetry if you don't have it already

--- a/src/kakarot/execution_context.cairo
+++ b/src/kakarot/execution_context.cairo
@@ -477,9 +477,7 @@ namespace ExecutionContext {
     // @param destroy_contracts_len Array length of destroy_contracts to add.
     // @param destroy_contracts The pointer to the new array of contracts to destroy.
     func push_to_destroy_contracts(
-        self: model.ExecutionContext*,
-        destroy_contracts_len: felt,
-        destroy_contracts: felt*,
+        self: model.ExecutionContext*, destroy_contracts_len: felt, destroy_contracts: felt*
     ) -> model.ExecutionContext* {
         Helpers.fill_array(
             fill_len=destroy_contracts_len,
@@ -503,15 +501,14 @@ namespace ExecutionContext {
             sub_context=self.sub_context,
             destroy_contracts_len=self.destroy_contracts_len + destroy_contracts_len,
             destroy_contracts=self.destroy_contracts,
-        ); 
+            );
     }
 
     // @notice Add one contract to the array of contracts to destroy.
     // @param self The pointer to the execution context.
     // @param destroy_contract contract to destroy.
     func push_to_destroy_contract(
-        self: model.ExecutionContext*,
-        destroy_contract: felt,
+        self: model.ExecutionContext*, destroy_contract: felt
     ) -> model.ExecutionContext* {
         assert [self.destroy_contracts + self.destroy_contracts_len] = destroy_contract;
         return new model.ExecutionContext(
@@ -531,7 +528,7 @@ namespace ExecutionContext {
             sub_context=self.sub_context,
             destroy_contracts_len=self.destroy_contracts_len + 1,
             destroy_contracts=self.destroy_contracts,
-        ); 
+            );
     }
 
     // @notice Dump the current execution context.

--- a/src/kakarot/instructions.cairo
+++ b/src/kakarot/instructions.cairo
@@ -28,7 +28,12 @@ from kakarot.instructions.logging_operations import LoggingOperations
 from kakarot.instructions.memory_operations import MemoryOperations
 from kakarot.instructions.environmental_information import EnvironmentalInformation
 from kakarot.instructions.block_information import BlockInformation
-from kakarot.instructions.system_operations import SystemOperations, CallHelper, CreateHelper, SelfDestructHelper
+from kakarot.instructions.system_operations import (
+    SystemOperations,
+    CallHelper,
+    CreateHelper,
+    SelfDestructHelper,
+)
 from kakarot.instructions.sha3 import Sha3
 from kakarot.interfaces.interfaces import IEvmContract
 

--- a/src/kakarot/interfaces/interfaces.cairo
+++ b/src/kakarot/interfaces/interfaces.cairo
@@ -31,7 +31,7 @@ namespace IBlockhashRegistry {
 namespace IEth {
     func balanceOf(account: felt) -> (balance: Uint256) {
     }
-    
+
     func transfer(recipient: felt, amount: Uint256) -> (success: felt) {
     }
 }

--- a/tests/unit/src/kakarot/instructions/test_environmental_information.py
+++ b/tests/unit/src/kakarot/instructions/test_environmental_information.py
@@ -4,6 +4,7 @@ import pytest
 import pytest_asyncio
 from starkware.starknet.testing.starknet import Starknet
 
+
 @pytest_asyncio.fixture(scope="module")
 async def environmental_information(starknet: Starknet):
     return await starknet.deploy(

--- a/tests/unit/src/kakarot/instructions/test_system_operations.cairo
+++ b/tests/unit/src/kakarot/instructions/test_system_operations.cairo
@@ -15,7 +15,12 @@ from kakarot.constants import Constants, native_token_address
 from kakarot.constants import evm_contract_class_hash, registry_address
 from kakarot.execution_context import ExecutionContext
 from kakarot.instructions.memory_operations import MemoryOperations
-from kakarot.instructions.system_operations import SystemOperations, CallHelper, CreateHelper, SelfDestructHelper
+from kakarot.instructions.system_operations import (
+    SystemOperations,
+    CallHelper,
+    CreateHelper,
+    SelfDestructHelper,
+)
 from kakarot.interfaces.interfaces import IEvmContract, IKakarot, IRegistry
 from kakarot.library import Kakarot
 from kakarot.model import model
@@ -546,9 +551,7 @@ func test__exec_create2__should_return_a_new_context_with_bytecode_from_memory_a
 @external
 func test__exec_selfdestruct__should_delete_account_bytecode{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}(
-    eth_address: felt, evm_contract_class_hash_: felt, registry_address_: felt
-) {
+}(eth_address: felt, evm_contract_class_hash_: felt, registry_address_: felt) {
     alloc_locals;
     evm_contract_class_hash.write(evm_contract_class_hash_);
     registry_address.write(registry_address_);
@@ -567,19 +570,19 @@ func test__exec_selfdestruct__should_delete_account_bytecode{
     assert [calldata] = '';
     local call_context: model.CallContext* = new model.CallContext(
         bytecode=bytecode, bytecode_len=0, calldata=calldata, calldata_len=1, value=0
-    );
-    let stack = Stack.push(stack, Uint256(10,0));
+        );
+    let stack = Stack.push(stack, Uint256(10, 0));
     let (sub_ctx: felt*) = alloc();
-    assert [sub_ctx] = cast(call_context, felt);   // call_context
-    assert [sub_ctx + 1] = 0;   // program_counter
-    assert [sub_ctx + 2] = 0;   // stopped
-    assert [sub_ctx + 3] = cast(return_data + 1, felt);   // return_data
-    assert [sub_ctx + 4] = 1;   // return_data_len
-    assert [sub_ctx + 5] = cast(stack, felt);   // stack
-    assert [sub_ctx + 6] = cast(memory, felt);   // memory
-    assert [sub_ctx + 7] = 0;   // gas_used
-    assert [sub_ctx + 8] = 0;   // gas_limit
-    assert [sub_ctx + 9] = 0;   // intrinsic_gas_cost
+    assert [sub_ctx] = cast(call_context, felt);  // call_context
+    assert [sub_ctx + 1] = 0;  // program_counter
+    assert [sub_ctx + 2] = 0;  // stopped
+    assert [sub_ctx + 3] = cast(return_data + 1, felt);  // return_data
+    assert [sub_ctx + 4] = 1;  // return_data_len
+    assert [sub_ctx + 5] = cast(stack, felt);  // stack
+    assert [sub_ctx + 6] = cast(memory, felt);  // memory
+    assert [sub_ctx + 7] = 0;  // gas_used
+    assert [sub_ctx + 8] = 0;  // gas_limit
+    assert [sub_ctx + 9] = 0;  // intrinsic_gas_cost
     assert [sub_ctx + 13] = 0;  // sub_context
     assert [sub_ctx + 14] = 0;  // destroy_contracts_len
     assert [sub_ctx + 15] = cast(destroy_contracts, felt);  // destroy_contracts
@@ -599,21 +602,23 @@ func test__exec_selfdestruct__should_delete_account_bytecode{
     let (bytecode) = alloc();
     assert [bytecode] = 1907;
     IEvmContract.write_bytecode(
-        contract_address=starknet_contract_address,
-        bytecode_len=1,
-        bytecode=bytecode
+        contract_address=starknet_contract_address, bytecode_len=1, bytecode=bytecode
     );
 
     // Create context
     let stack: model.Stack* = Stack.init();
     let (bytecode) = alloc();
-    let ctx = TestHelpers.init_context_with_stack_and_sub_ctx(0, bytecode, stack, cast(sub_ctx, model.ExecutionContext*));
+    let ctx = TestHelpers.init_context_with_stack_and_sub_ctx(
+        0, bytecode, stack, cast(sub_ctx, model.ExecutionContext*)
+    );
     assert [sub_ctx + 12] = cast(ctx, felt);  // calling_context
 
     let sub_ctx_object: model.ExecutionContext* = cast(sub_ctx, model.ExecutionContext*);
 
     // When
-    let sub_ctx_object: model.ExecutionContext* = SystemOperations.exec_selfdestruct(sub_ctx_object);
+    let sub_ctx_object: model.ExecutionContext* = SystemOperations.exec_selfdestruct(
+        sub_ctx_object
+    );
 
     // Simulate run
     let ctx = CallHelper.finalize_calling_context(sub_ctx_object);
@@ -629,5 +634,5 @@ func test__exec_selfdestruct__should_delete_account_bytecode{
 
     assert evm_contract_address = 0;
     assert evm_contract_byte_len = 0;
-    return();
+    return ();
 }

--- a/tests/unit/src/kakarot/instructions/test_system_operations.py
+++ b/tests/unit/src/kakarot/instructions/test_system_operations.py
@@ -71,6 +71,7 @@ class TestSystemOperations:
             contract_account_class.class_hash,
             account_registry.contract_address,
         ).call()
+
     async def test_selfdestruct(
         self, system_operations, contract_account_class, account_registry, eth
     ):


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Markdown linting underlines images without alt text (ie. `![](path/to/file.png)`.

## What is the new behavior?

Rule is disabled so markdown linting does not show this as an error.

## Other information

Time spent on this PR:  0.01 day
