### PR TITLE
Fix state update is persisted across tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,11 +100,12 @@ markers = [
     "RETURN:         Opcode Value 0xf3 - Halt execution returning output data",
     "REVERT:         Opcode value 0xfd - Halt execution reverting state changes",
     "INVALID:        Opcode Value 0xfe - Designated invalid instruction",
-    "SolmateERC20",
-    "SolmateERC721",
-    "IntegrationTestContract",
     "Precompiles",
     "EC_RECOVER:     Precompile Value 0x01 - Elliptic curve digital signature algorithm (ECDSA) public key recovery function",
+    "Counter",
+    "PlainOpcodes",
+    "SolmateERC20",
+    "SolmateERC721",
 ]
 
 [tool.isort]

--- a/tests/fixtures/1_starknet.py
+++ b/tests/fixtures/1_starknet.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import AsyncGenerator
 
 import pandas as pd
+import pytest
 import pytest_asyncio
 from cairo_coverage import cairo_coverage
 from starkware.starknet.business_logic.execution.execute_entry_point import (
@@ -80,3 +81,16 @@ async def starknet(worker_id, request, blockhashes) -> AsyncGenerator[Starknet, 
                 times.sort_values(["duration"], ascending=False).to_csv(
                     output_dir / "times.csv", index=False
                 )
+
+
+@pytest.fixture(autouse=True)
+def starknet_snapshot(starknet):
+    """
+    Auto used fixture to snapshot the starknet state before each test and reset it at teardown
+    """
+    initial_state = starknet.state.copy()
+
+    yield
+
+    initial_cache_state = initial_state.state._copy()
+    starknet.state.state = initial_cache_state

--- a/tests/integration/solidity_contracts/Counter/test_counter.py
+++ b/tests/integration/solidity_contracts/Counter/test_counter.py
@@ -1,228 +1,34 @@
-from typing import Callable
+import re
 
 import pytest
-from starkware.starknet.testing.contract import StarknetContract
-
-from tests.integration.helpers.helpers import (
-    extract_memory_from_execute,
-    hex_string_to_bytes_array,
-)
 
 
 @pytest.mark.asyncio
+@pytest.mark.Counter
 class TestCounter:
-    # TODO move opcodes testing in the PlainOpcode contract
-    async def test_extcodecopy_counter(
-        self, deploy_solidity_contract: Callable, kakarot: StarknetContract
-    ):
+    class TestCount:
+        async def test_should_return_0_after_deployment(self, counter):
+            assert await counter.count() == 0
 
-        counter = await deploy_solidity_contract("Counter", "Counter", caller_address=1)
+    class TestInc:
+        async def test_should_increase_count(self, counter, addresses):
+            await counter.inc(caller_address=addresses[1].starknet_address)
+            assert await counter.count() == 1
 
-        evm_contract_address = (
-            counter.contract_account.deploy_call_info.result.evm_contract_address
-        )
+    class TestDec:
+        async def test_should_raise_when_count_is_0(self, counter, addresses):
+            with pytest.raises(Exception) as e:
+                await counter.dec(caller_address=addresses[1].starknet_address)
+            message = re.search(r"Error message: (.*)", e.value.message)[1]  # type: ignore
+            assert message == "Kakarot: Reverted with reason: 32"
 
-        # instructions
-        push1 = 60
-        push20 = 73
-        extcodecopy = "3c"
+        async def test_should_decrease_count(self, counter, addresses):
+            await counter.inc(caller_address=addresses[1].starknet_address)
+            await counter.dec(caller_address=addresses[1].starknet_address)
+            assert await counter.count() == 0
 
-        # stack elements
-        offset = 0
-        size = 8
-        dest_offset = 0
-
-        byte_code = f"{push1}\
-        {size:02x}\
-        {push1}\
-        {offset:02x}\
-        {push1}\
-        {dest_offset:02x}\
-        {push20}\
-        {evm_contract_address:x}\
-        {extcodecopy}"
-
-        res = await kakarot.execute(
-            value=int(0),
-            bytecode=hex_string_to_bytes_array(byte_code),
-            calldata=hex_string_to_bytes_array(""),
-        ).call(caller_address=1)
-
-        expected_memory_result = hex_string_to_bytes_array(counter.bytecode.hex())
-        memory_result = extract_memory_from_execute(res.result)
-
-        assert (
-            memory_result[dest_offset : size + dest_offset]
-            == expected_memory_result[offset : offset + size]
-        )
-
-        # instructions
-        push1 = 60
-        push20 = 73
-        extcodecopy = "3c"
-
-        # stack elements
-        offset = 10
-        size = 9
-        dest_offset = 100
-
-        byte_code = f"{push1}\
-        {size:02x}\
-        {push1}\
-        {offset:02x}\
-        {push1}\
-        {dest_offset:02x}\
-        {push20}\
-        {evm_contract_address:x}\
-        {extcodecopy}"
-
-        res = await kakarot.execute(
-            value=int(0),
-            bytecode=hex_string_to_bytes_array(byte_code),
-            calldata=hex_string_to_bytes_array(""),
-        ).call(caller_address=1)
-
-        memory_result = extract_memory_from_execute(res.result)
-
-        assert (
-            memory_result[dest_offset : size + dest_offset]
-            == expected_memory_result[offset : offset + size]
-        )
-
-    @pytest.mark.skip(
-        "Investigate why memory results differ in cases where offset and size are gte twenty"
-    )
-    async def test_extcodecopy_offset_and_size_gte_twenty_a(
-        self, deploy_solidity_contract: Callable, kakarot: StarknetContract
-    ):
-        counter = await deploy_solidity_contract("Counter", "Counter", caller_address=1)
-
-        evm_contract_address = (
-            counter.contract_account.deploy_call_info.result.evm_contract_address
-        )
-        expected_memory_result = hex_string_to_bytes_array(counter.bytecode.hex())
-
-        # instructions
-        push1 = 60
-        push20 = 73
-        extcodecopy = "3c"
-
-        # stack elements
-        offset = 10
-        size = 10
-        dest_offset = 0
-
-        byte_code = f"{push1}\
-        {size:02x}\
-        {push1}\
-        {offset:02x}\
-        {push1}\
-        {dest_offset:02x}\
-        {push20}\
-        {evm_contract_address:x}\
-        {extcodecopy}"
-
-        res = await kakarot.execute(
-            value=int(0),
-            bytecode=hex_string_to_bytes_array(byte_code),
-            calldata=hex_string_to_bytes_array(""),
-        ).call(caller_address=1)
-
-        memory_result = extract_memory_from_execute(res.result)
-
-        assert (
-            memory_result[dest_offset : size + dest_offset]
-            == expected_memory_result[offset : offset + size]
-        )
-
-    @pytest.mark.skip(
-        "Investigate why memory results differ in cases where offset and size are gte twenty"
-    )
-    async def test_extcodecopy_offset_and_size_gte_twenty_b(
-        self, deploy_solidity_contract: Callable, kakarot: StarknetContract
-    ):
-        counter = await deploy_solidity_contract("Counter", "Counter", caller_address=1)
-
-        evm_contract_address = (
-            counter.contract_account.deploy_call_info.result.evm_contract_address
-        )
-        expected_memory_result = hex_string_to_bytes_array(counter.bytecode.hex())
-
-        # instructions
-        push1 = 60
-        push20 = 73
-        extcodecopy = "3c"
-
-        # stack elements
-        offset = 11
-        size = 9
-        dest_offset = 0
-
-        byte_code = f"{push1}\
-        {size:02x}\
-        {push1}\
-        {offset:02x}\
-        {push1}\
-        {dest_offset:02x}\
-        {push20}\
-        {evm_contract_address:x}\
-        {extcodecopy}"
-
-        res = await kakarot.execute(
-            value=int(0),
-            bytecode=hex_string_to_bytes_array(byte_code),
-            calldata=hex_string_to_bytes_array(""),
-        ).call(caller_address=1)
-
-        memory_result = extract_memory_from_execute(res.result)
-
-        assert (
-            memory_result[dest_offset : size + dest_offset]
-            == expected_memory_result[offset : offset + size]
-        )
-
-    @pytest.mark.skip(
-        "Investigate why memory results differ in cases where offset and size are gte twenty"
-    )
-    async def test_extcodecopy_offset_and_size_gte_twenty_c(
-        self, deploy_solidity_contract: Callable, kakarot: StarknetContract
-    ):
-        counter = await deploy_solidity_contract("Counter", "Counter", caller_address=1)
-
-        evm_contract_address = (
-            counter.contract_account.deploy_call_info.result.evm_contract_address
-        )
-        expected_memory_result = hex_string_to_bytes_array(counter.bytecode.hex())
-
-        # instructions
-        push1 = 60
-        push20 = 73
-        extcodecopy = "3c"
-
-        # stack elements
-        offset = 18
-        size = 3
-        dest_offset = 0
-
-        byte_code = f"{push1}\
-        {size:02x}\
-        {push1}\
-        {offset:02x}\
-        {push1}\
-        {dest_offset:02x}\
-        {push20}\
-        {evm_contract_address:x}\
-        {extcodecopy}"
-
-        res = await kakarot.execute(
-            value=int(0),
-            bytecode=hex_string_to_bytes_array(byte_code),
-            calldata=hex_string_to_bytes_array(""),
-        ).call(caller_address=1)
-
-        memory_result = extract_memory_from_execute(res.result)
-
-        assert (
-            memory_result[dest_offset : size + dest_offset]
-            == expected_memory_result[offset : offset + size]
-        )
+    class TestReset:
+        async def test_should_set_count_to_0(self, counter, addresses):
+            await counter.inc(caller_address=addresses[1].starknet_address)
+            await counter.reset(caller_address=addresses[1].starknet_address)
+            assert await counter.count() == 0

--- a/tests/integration/solidity_contracts/PlainOpcodes/PlainOpcodes.sol
+++ b/tests/integration/solidity_contracts/PlainOpcodes/PlainOpcodes.sol
@@ -30,7 +30,9 @@ contract PlainOpcodes {
     /*//////////////////////////////////////////////////////////////
                             FUNCTIONS FOR OPCODES
     //////////////////////////////////////////////////////////////*/
-    function opcodeBlockHash(uint256 blockNumber) public view returns (bytes32 _blockhash) {
+    function opcodeBlockHash(
+        uint256 blockNumber
+    ) public view returns (bytes32 _blockhash) {
         return (blockhash(blockNumber));
     }
 
@@ -42,10 +44,9 @@ contract PlainOpcodes {
         return counter.count();
     }
 
-    function opcodeStaticCall2() public {
+    function opcodeStaticCall2() public view returns (bool, bytes memory) {
         bytes memory data = abi.encodeWithSelector(bytes4(keccak256("inc()")));
-        address(counter).staticcall(data);
-
+        return address(counter).staticcall(data);
     }
 
     function opcodeCall() public {

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
@@ -1,112 +1,310 @@
-from typing import Callable
+import re
 
 import pytest
-from web3 import Web3
 
-MOCK_COUNTER_ADDRESS = Web3.toChecksumAddress("0x" + hex(42)[2:].rjust(40, "0"))
+from tests.integration.helpers.helpers import (
+    extract_memory_from_execute,
+    hex_string_to_bytes_array,
+)
 
 
 @pytest.mark.asyncio
-@pytest.mark.IntegrationTestContract
+@pytest.mark.PlainOpcodes
 class TestPlainOpcodes:
-    class TestCall:
-        async def test_staticcall_should_not_increase_counter(
-            self,
-            deploy_solidity_contract: Callable,
-            addresses,
-        ):
-            counter = await deploy_solidity_contract(
-                "Counter", "Counter", caller_address=addresses[1]["int"]
-            )
-            counter_address = Web3.toChecksumAddress(
-                "0x"
-                + hex(
-                    counter.contract_account.deploy_call_info.result.evm_contract_address
-                )[2:].rjust(40, "0")
-            )
-            integration_contract = await deploy_solidity_contract(
-                "PlainOpcodes",
-                "PlainOpcodes",
-                counter_address,
-                caller_address=addresses[1]["int"],
-            )
+    class TestStaticCall:
+        async def test_should_return_counter_count(self, counter, plain_opcodes):
+            assert await plain_opcodes.opcodeStaticCall() == await counter.count()
 
+        async def test_should_revert_when_trying_to_modify_state(
+            self,
+            plain_opcodes,
+        ):
             with pytest.raises(Exception) as e:
-                await integration_contract.opcodeStaticCall2(
-                    caller_address=addresses[1]["int"]
-                )
-                message = re.search(r"Error message: (.*)", e.value.message)[1]  # type: ignore
-                assert message == "Kakarot: StateModificationError"
+                await plain_opcodes.opcodeStaticCall2()
+            message = re.search(r"Error message: (.*)", e.value.message)[1]  # type: ignore
+            assert message == "Kakarot: StateModificationError"
 
-        async def test_should_return_counter_count_and_increase_it(
+    class TestCall:
+        async def test_should_increase_counter(
             self,
-            deploy_solidity_contract: Callable,
+            counter,
+            plain_opcodes,
             addresses,
         ):
-            counter = await deploy_solidity_contract(
-                "Counter", "Counter", caller_address=addresses[1]["int"]
-            )
-            counter_address = Web3.toChecksumAddress(
-                "0x"
-                + hex(
-                    counter.contract_account.deploy_call_info.result.evm_contract_address
-                )[2:].rjust(40, "0")
-            )
-            integration_contract = await deploy_solidity_contract(
-                "PlainOpcodes",
-                "PlainOpcodes",
-                counter_address,
-                caller_address=addresses[1]["int"],
-            )
-
-            count = await integration_contract.opcodeStaticCall()
-            assert count == 0
-            await integration_contract.opcodeCall(caller_address=addresses[1]["int"])
-            count = await integration_contract.opcodeStaticCall()
-            assert count == 1
+            await plain_opcodes.opcodeCall(caller_address=addresses[1].starknet_address)
+            assert await counter.count() == 1
 
     class TestBlockhash:
-        async def test_should_return_blockhash(
+        async def test_should_return_blockhash_with_valid_block_number(
             self,
-            deploy_solidity_contract: Callable,
-            addresses,
+            plain_opcodes,
             blockhashes,
         ):
-            integration_contract = await deploy_solidity_contract(
-                "PlainOpcodes",
-                "PlainOpcodes",
-                MOCK_COUNTER_ADDRESS,  # opcode doesn't need this deploy
-                caller_address=addresses[1]["int"],
-            )
-
             block_number = max(blockhashes["last_256_blocks"].keys())
-            blockhash = await integration_contract.opcodeBlockHash(int(block_number))
+            blockhash = await plain_opcodes.opcodeBlockHash(int(block_number))
 
             assert (
                 int.from_bytes(blockhash, byteorder="big")
                 == blockhashes["last_256_blocks"][block_number]
             )
 
-            blockhash_invalid_number = await integration_contract.opcodeBlockHash(1)
+            blockhash_invalid_number = await plain_opcodes.opcodeBlockHash(1)
+
+            assert int.from_bytes(blockhash_invalid_number, byteorder="big") == 0
+
+        async def test_should_return_0_with_invalid_block_number(
+            self,
+            plain_opcodes,
+        ):
+            blockhash_invalid_number = await plain_opcodes.opcodeBlockHash(1)
 
             assert int.from_bytes(blockhash_invalid_number, byteorder="big") == 0
 
     class TestAddress:
         async def test_should_return_self_address(
             self,
-            deploy_solidity_contract: Callable,
-            addresses,
+            plain_opcodes,
         ):
-            integration_contract = await deploy_solidity_contract(
-                "PlainOpcodes",
-                "PlainOpcodes",
-                MOCK_COUNTER_ADDRESS,  # opcode doesn't need this deploy
-                caller_address=addresses[1]["int"],
+            evm_contract_address = await plain_opcodes.opcodeAddress()
+
+            assert int(plain_opcodes.evm_contract_address, 16) == int(
+                evm_contract_address, 16
             )
 
-            evm_contract_address = await integration_contract.opcodeAddress()
+    class TestExtCodeCopy:
+        async def test_extcodecopy_counter(self, counter, kakarot):
+            evm_contract_address = (
+                counter.contract_account.deploy_call_info.result.evm_contract_address
+            )
+
+            # instructions
+            push1 = 60
+            push20 = 73
+            extcodecopy = "3c"
+
+            # stack elements
+            offset = 0
+            size = 8
+            dest_offset = 0
+
+            byte_code = f"{push1}\
+            {size:02x}\
+            {push1}\
+            {offset:02x}\
+            {push1}\
+            {dest_offset:02x}\
+            {push20}\
+            {evm_contract_address:x}\
+            {extcodecopy}"
+
+            res = await kakarot.execute(
+                value=int(0),
+                bytecode=hex_string_to_bytes_array(byte_code),
+                calldata=hex_string_to_bytes_array(""),
+            ).call(caller_address=1)
+
+            expected_memory_result = hex_string_to_bytes_array(counter.bytecode.hex())
+            memory_result = extract_memory_from_execute(res.result)
 
             assert (
-                integration_contract.contract_account.deploy_call_info.result.evm_contract_address
-                == int(evm_contract_address, 16)
+                memory_result[dest_offset : size + dest_offset]
+                == expected_memory_result[offset : offset + size]
             )
+
+            # instructions
+            push1 = 60
+            push20 = 73
+            extcodecopy = "3c"
+
+            # stack elements
+            offset = 10
+            size = 9
+            dest_offset = 100
+
+            byte_code = f"{push1}\
+            {size:02x}\
+            {push1}\
+            {offset:02x}\
+            {push1}\
+            {dest_offset:02x}\
+            {push20}\
+            {evm_contract_address:x}\
+            {extcodecopy}"
+
+            res = await kakarot.execute(
+                value=int(0),
+                bytecode=hex_string_to_bytes_array(byte_code),
+                calldata=hex_string_to_bytes_array(""),
+            ).call(caller_address=1)
+
+            memory_result = extract_memory_from_execute(res.result)
+
+            assert (
+                memory_result[dest_offset : size + dest_offset]
+                == expected_memory_result[offset : offset + size]
+            )
+
+        @pytest.mark.skip(
+            "Investigate why memory results differ in cases where offset and size are gte twenty"
+        )
+        async def test_extcodecopy_offset_and_size_gte_twenty_a(self, counter, kakarot):
+            evm_contract_address = (
+                counter.contract_account.deploy_call_info.result.evm_contract_address
+            )
+            expected_memory_result = hex_string_to_bytes_array(counter.bytecode.hex())
+
+            # instructions
+            push1 = 60
+            push20 = 73
+            extcodecopy = "3c"
+
+            # stack elements
+            offset = 10
+            size = 10
+            dest_offset = 0
+
+            byte_code = f"{push1}\
+            {size:02x}\
+            {push1}\
+            {offset:02x}\
+            {push1}\
+            {dest_offset:02x}\
+            {push20}\
+            {evm_contract_address:x}\
+            {extcodecopy}"
+
+            res = await kakarot.execute(
+                value=int(0),
+                bytecode=hex_string_to_bytes_array(byte_code),
+                calldata=hex_string_to_bytes_array(""),
+            ).call(caller_address=1)
+
+            memory_result = extract_memory_from_execute(res.result)
+
+            assert (
+                memory_result[dest_offset : size + dest_offset]
+                == expected_memory_result[offset : offset + size]
+            )
+
+        @pytest.mark.skip(
+            "Investigate why memory results differ in cases where offset and size are gte twenty"
+        )
+        async def test_extcodecopy_offset_and_size_gte_twenty_b(self, counter, kakarot):
+            evm_contract_address = (
+                counter.contract_account.deploy_call_info.result.evm_contract_address
+            )
+            expected_memory_result = hex_string_to_bytes_array(counter.bytecode.hex())
+
+            # instructions
+            push1 = 60
+            push20 = 73
+            extcodecopy = "3c"
+
+            # stack elements
+            offset = 11
+            size = 9
+            dest_offset = 0
+
+            byte_code = f"{push1}\
+            {size:02x}\
+            {push1}\
+            {offset:02x}\
+            {push1}\
+            {dest_offset:02x}\
+            {push20}\
+            {evm_contract_address:x}\
+            {extcodecopy}"
+
+            res = await kakarot.execute(
+                value=int(0),
+                bytecode=hex_string_to_bytes_array(byte_code),
+                calldata=hex_string_to_bytes_array(""),
+            ).call(caller_address=1)
+
+            memory_result = extract_memory_from_execute(res.result)
+
+            assert (
+                memory_result[dest_offset : size + dest_offset]
+                == expected_memory_result[offset : offset + size]
+            )
+
+        @pytest.mark.skip(
+            "Investigate why memory results differ in cases where offset and size are gte twenty"
+        )
+        async def test_extcodecopy_offset_and_size_gte_twenty_c(self, counter, kakarot):
+            evm_contract_address = (
+                counter.contract_account.deploy_call_info.result.evm_contract_address
+            )
+            expected_memory_result = hex_string_to_bytes_array(counter.bytecode.hex())
+
+            # instructions
+            push1 = 60
+            push20 = 73
+            extcodecopy = "3c"
+
+            # stack elements
+            offset = 18
+            size = 3
+            dest_offset = 0
+
+            byte_code = f"{push1}\
+            {size:02x}\
+            {push1}\
+            {offset:02x}\
+            {push1}\
+            {dest_offset:02x}\
+            {push20}\
+            {evm_contract_address:x}\
+            {extcodecopy}"
+
+            res = await kakarot.execute(
+                value=int(0),
+                bytecode=hex_string_to_bytes_array(byte_code),
+                calldata=hex_string_to_bytes_array(""),
+            ).call(caller_address=1)
+
+            memory_result = extract_memory_from_execute(res.result)
+
+            assert (
+                memory_result[dest_offset : size + dest_offset]
+                == expected_memory_result[offset : offset + size]
+            )
+
+        @pytest.mark.skip(
+            "Investigate why there is a difference between local and deployed contract code in the erc20 contract"
+        )
+        async def test_extcodecopy_erc20(self, erc_20, kakarot):
+            evm_contract_address = (
+                erc_20.contract_account.deploy_call_info.result.evm_contract_address
+            )
+
+            # instructions
+            push1 = 60
+            push20 = 73
+            extcodecopy = "3c"
+
+            # stack elements
+            offset = 0
+            size = 8
+            dest_offset = 0
+
+            byte_code = f"{push1}\
+            {size:02x}\
+            {push1}\
+            {offset:02x}\
+            {push1}\
+            {dest_offset:02x}\
+            {push20}\
+            {evm_contract_address:x}\
+            {extcodecopy}"
+
+            res = await kakarot.execute(
+                value=int(0),
+                bytecode=hex_string_to_bytes_array(byte_code),
+                calldata=hex_string_to_bytes_array(""),
+            ).call(caller_address=1)
+
+            expected_memory_result = hex_string_to_bytes_array(erc_20.bytecode.hex())
+            memory_result = extract_memory_from_execute(res.result)
+            # asserting to the first discrepancy
+            assert memory_result[dest_offset:2] == expected_memory_result[offset:2]

--- a/tests/integration/solidity_contracts/Solmate/test_erc721.py
+++ b/tests/integration/solidity_contracts/Solmate/test_erc721.py
@@ -1,5 +1,3 @@
-from typing import Callable
-
 import pytest
 
 
@@ -7,13 +5,7 @@ import pytest
 @pytest.mark.SolmateERC721
 class TestERC721:
     class TestDeploy:
-        async def test_should_set_name_and_symbol(
-            self,
-            deploy_solidity_contract: Callable,
-        ):
-            erc_721 = await deploy_solidity_contract(
-                "Solmate", "ERC721", "Kakarot NFT", "KKNFT", caller_address=1
-            )
+        async def test_should_set_name_and_symbol(self, erc_721):
             name = await erc_721.name()
             assert name == "Kakarot NFT"
             symbol = await erc_721.symbol()


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When using a Solidity contracts in tests, state modifications are persisted across different tests.
Furthermore it's not possible to deploy to times the same contract (with different constructor args for example).

## What is the new behavior?

The `StarknetState` is cached in an `autouse` fixture; contracts can be deployed at module level, cached while state is reset after each test to its initial value.

## Other information

I have moved some tests according to TODOs that were written herein (test concerning EXTCODECOPY inside test_erc20 and test_counter.
`Counter.sol` actually had no test so I wrote a bunch of them.

Time spent on this PR:  1 day
