### PR TITLE
Parse events data for solidity contracts

### DIFF
--- a/tests/integration/helpers/wrap_kakarot.py
+++ b/tests/integration/helpers/wrap_kakarot.py
@@ -5,8 +5,10 @@ from typing import cast
 from starkware.starknet.testing.starknet import StarknetContract
 from web3 import Web3
 from web3._utils.abi import map_abi_data
+from web3._utils.events import get_event_data
 from web3._utils.normalizers import BASE_RETURN_NORMALIZERS
 from web3.contract import Contract
+from web3.types import LogReceipt
 
 from tests.integration.helpers.helpers import hex_string_to_bytes_array
 from tests.utils.reporting import traceit
@@ -68,11 +70,43 @@ def wrap_for_kakarot(
                     args=args,
                     kwargs=kwargs,
                 )
+
+            codec = Web3().codec
             types = [o["type"] for o in abi["outputs"]]
             data = bytearray(res.result.return_data)
-            decoded = Web3().codec.decode(types, data)
+            decoded = codec.decode(types, data)
             normalized = map_abi_data(BASE_RETURN_NORMALIZERS, types, decoded)
-            return normalized[0] if len(normalized) == 1 else normalized
+            result = normalized[0] if len(normalized) == 1 else normalized
+            log_receipts = [
+                LogReceipt(
+                    address=Web3.toChecksumAddress(f"{evm_contract_address:040x}"),
+                    blockHash=bytes(),
+                    blockNumber=bytes(),
+                    data=bytes(event.data),
+                    logIndex=log_index,
+                    topic=bytes(),
+                    topics=[
+                        bytes.fromhex(
+                            f"{(event.keys[i] + 2**128 * event.keys[i + 1]):064x}"
+                        )
+                        for i in range(0, len(event.keys), 2)
+                    ],
+                    transactionHash=bytes(),
+                    transactionIndex=0,
+                )
+                for log_index, event in enumerate(res.raw_events)
+            ]
+
+            for event_abi in contract.events._events:
+                logs = []
+                for log_receipt in log_receipts:
+                    try:
+                        logs += [get_event_data(codec, event_abi, log_receipt).args]
+                    except:
+                        pass
+                setattr(contract.events, event_abi["name"], logs)
+
+            return result
 
         return _wrapped
 

--- a/tests/integration/helpers/wrap_kakarot.py
+++ b/tests/integration/helpers/wrap_kakarot.py
@@ -87,6 +87,10 @@ def wrap_for_kakarot(
                     topic=bytes(),
                     topics=[
                         bytes.fromhex(
+                            # event "keys" in cairo are event "topics" in solidity
+                            # they're returned as list where consecutive values are indeed
+                            # low, high, low, high, etc. of the Uint256 cairo representation
+                            # of the bytes32 topics. This recomputes the original topic
                             f"{(event.keys[i] + 2**128 * event.keys[i + 1]):064x}"
                         )
                         for i in range(0, len(event.keys), 2)

--- a/tests/integration/solidity_contracts/PlainOpcodes/PlainOpcodes.sol
+++ b/tests/integration/solidity_contracts/PlainOpcodes/PlainOpcodes.sol
@@ -19,6 +19,16 @@ contract PlainOpcodes {
                             METADATA STORAGE
     //////////////////////////////////////////////////////////////*/
     ICounter counter;
+    event Log0() anonymous;
+    event Log0Value(uint256 value) anonymous;
+    event Log1(uint256 value);
+    event Log2(address indexed owner, uint256 value);
+    event Log3(address indexed owner, address indexed spender, uint256 value);
+    event Log4(
+        address indexed owner,
+        address indexed spender,
+        uint256 indexed value
+    );
 
     /*//////////////////////////////////////////////////////////////
                                CONSTRUCTOR
@@ -51,5 +61,29 @@ contract PlainOpcodes {
 
     function opcodeCall() public {
         counter.inc();
+    }
+
+    function opcodeLog0() public {
+        emit Log0();
+    }
+
+    function opcodeLog0Value() public {
+        emit Log0Value(10);
+    }
+
+    function opcodeLog1() public {
+        emit Log1(10);
+    }
+
+    function opcodeLog2() public {
+        emit Log2(address(0xa), 10);
+    }
+
+    function opcodeLog3() public {
+        emit Log3(address(0xa), address(0xb), 10);
+    }
+
+    function opcodeLog4() public {
+        emit Log4(address(0xa), address(0xb), 10);
     }
 }


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

There is no way to test events emitted by a Solidity contract

## What is the new behavior?

Contract's events can be accessed with `contract.events.{event_name}` (one attribute per event).
This returns a list of emitted events in the last transaction; events are described as dict, eg.:

```
await token.approve(...)
assert token.events.Approval == [{
    "owner": "0x..",
    "spender": "0x...",
    "value": 10,
}]
```

## Other information

`web3.Contract` class already had `events.{event_name}` attributes. I've overridden this attribute to ease manipulation in our context.

Time spent on this PR:  1 day

