### PR TITLE
Add tests for CREATE2 and require in PlainOpcodes

### DIFF
--- a/tests/fixtures/2_kakarot.py
+++ b/tests/fixtures/2_kakarot.py
@@ -13,7 +13,7 @@ async def eth(starknet: Starknet):
 
 
 @pytest_asyncio.fixture(scope="session")
-async def contract_account_class(starknet: Starknet):
+async def contract_account_class(starknet: Starknet) -> DeclaredClass:
     return await starknet.declare(
         source="./src/kakarot/accounts/contract/contract_account.cairo",
         cairo_path=["src"],

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,6 +5,9 @@ from typing import List
 
 import pytest
 import pytest_asyncio
+from starkware.starknet.core.os.contract_address.contract_address import (
+    calculate_contract_address_from_hash,
+)
 from starkware.starknet.testing.contract import StarknetContract
 from web3 import Web3
 
@@ -19,7 +22,56 @@ logger = logging.getLogger()
 
 
 @pytest.fixture(scope="package")
-def deploy_solidity_contract(starknet, contract_account_class, kakarot):
+def get_starknet_address(contract_account_class, kakarot):
+    """
+    Fixture to return the starknet address of a contract deployed by kakarot using CREATE2
+    """
+
+    def _factory(salt):
+        return calculate_contract_address_from_hash(
+            salt=salt,
+            class_hash=contract_account_class.class_hash,
+            constructor_calldata=[kakarot.contract_address, 0],
+            deployer_address=kakarot.contract_address,
+        )
+
+    return _factory
+
+
+@pytest.fixture(scope="package")
+def get_solidity_contract(starknet, contract_account_class, kakarot):
+    """
+    Fixture to attach a modified web3.contract instance to an already deployed contract_account in kakarot.
+    """
+
+    def _factory(
+        contract_app, contract_name, starknet_contract_address, evm_contract_address, tx
+    ):
+        """
+        This factory is what is actually returned by pytest when requesting the `get_solidity_contract`
+        fixture.
+        It creates a web3.contract based on the basename of the target solidity file.
+        """
+        contract_account = StarknetContract(
+            starknet.state,
+            contract_account_class.abi,
+            starknet_contract_address,
+            tx,
+        )
+        contract = get_contract(contract_app, contract_name)
+        kakarot_contract = wrap_for_kakarot(
+            contract, kakarot, int(evm_contract_address, 16)
+        )
+        setattr(kakarot_contract, "contract_account", contract_account)
+        setattr(kakarot_contract, "evm_contract_address", evm_contract_address)
+
+        return kakarot_contract
+
+    return _factory
+
+
+@pytest.fixture(scope="package")
+def deploy_solidity_contract(kakarot, get_solidity_contract):
     """
     Fixture to deploy a solidity contract in kakarot. The returned contract is a modified
     web3.contract instance with an added `contract_account` attribute that return the actual
@@ -54,26 +106,16 @@ def deploy_solidity_contract(starknet, contract_account_class, kakarot):
             )
 
         starknet_contract_address = tx.result.starknet_contract_address
-        contract_account = StarknetContract(
-            starknet.state,
-            contract_account_class.abi,
+        evm_contract_address = Web3.toChecksumAddress(
+            f"{tx.result.evm_contract_address:040x}"
+        )
+        return get_solidity_contract(
+            contract_app,
+            contract_name,
             starknet_contract_address,
+            evm_contract_address,
             tx,
         )
-
-        kakarot_contract = wrap_for_kakarot(
-            contract, kakarot, tx.result.evm_contract_address
-        )
-        evm_contract_address = Web3.toChecksumAddress(
-            "0x"
-            + hex(contract_account.deploy_call_info.result.evm_contract_address)[
-                2:
-            ].rjust(40, "0")
-        )
-        setattr(kakarot_contract, "contract_account", contract_account)
-        setattr(kakarot_contract, "evm_contract_address", evm_contract_address)
-
-        return kakarot_contract
 
     return _factory
 

--- a/tests/integration/helpers/helpers.py
+++ b/tests/integration/helpers/helpers.py
@@ -73,22 +73,16 @@ def get_domain_separator(name: str, token_address: str) -> bytes:
 
 
 def get_create2_address(
-    factory_address: str, token_a: str, token_b: str, bytecode: bytes
+    sender_address: str, salt: bytes, initialization_code: bytes
 ) -> str:
-    token_0, token_1 = sorted([token_a, token_b])
-    create2_inputs = [
-        b"\xff",
-        decode_hex(factory_address),
+    """
+    See [CREATE2](https://www.evm.codes/#f5)
+    """
+    return to_checksum_address(
         keccak(
-            encode_abi(
-                ["address", "address"],
-                [token_0, token_1],
-            )
-        ),
-        keccak(bytecode),
-    ]
-    sanitized_inputs = b"".join(create2_inputs[2:])
-    return to_checksum_address(keccak(sanitized_inputs)[-40:])
+            b"\xff" + decode_hex(sender_address) + salt + keccak(initialization_code)
+        ).hex()[-40:]
+    )
 
 
 def get_approval_digest(

--- a/tests/integration/helpers/helpers.py
+++ b/tests/integration/helpers/helpers.py
@@ -81,7 +81,7 @@ def get_create2_address(
     return to_checksum_address(
         keccak(
             b"\xff" + decode_hex(sender_address) + salt + keccak(initialization_code)
-        ).hex()[-40:]
+        )[-20:]
     )
 
 

--- a/tests/integration/solidity_contracts/PlainOpcodes/PlainOpcodes.sol
+++ b/tests/integration/solidity_contracts/PlainOpcodes/PlainOpcodes.sol
@@ -86,4 +86,17 @@ contract PlainOpcodes {
     function opcodeLog4() public {
         emit Log4(address(0xa), address(0xb), 10);
     }
+
+    function create2(
+        bytes memory bytecode,
+        uint256 salt
+    ) public returns (address _address) {
+        assembly {
+            _address := create2(0, add(bytecode, 32), mload(bytecode), salt)
+        }
+    }
+
+    function requireNotZero(address _address) external pure {
+        require(_address != address(0), "ZERO_ADDRESS");
+    }
 }

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
@@ -345,3 +345,44 @@ class TestPlainOpcodes:
         async def test_should_emit_log4(self, plain_opcodes, addresses, event):
             await plain_opcodes.opcodeLog4(caller_address=addresses[0].starknet_address)
             assert plain_opcodes.events.Log4 == [event]
+
+    class TestCreate2:
+        async def test_should_deploy_bytecode_at_address(
+            self,
+            plain_opcodes,
+            counter,
+            addresses,
+            get_starknet_address,
+            get_solidity_contract,
+        ):
+            salt = 1234
+            evm_address = await plain_opcodes.create2(
+                counter.constructor().data_in_transaction,
+                salt,
+                caller_address=addresses[0].starknet_address,
+            )
+            starknet_address = get_starknet_address(salt)
+            deployed_counter = get_solidity_contract(
+                "Counter", "Counter", starknet_address, evm_address, None
+            )
+            assert await deployed_counter.count() == 0
+
+    class TestRequire:
+        async def test_should_revert_when_address_is_zero(
+            self, plain_opcodes, addresses
+        ):
+            with kakarot_error("ZERO_ADDRESS"):
+                await plain_opcodes.requireNotZero(
+                    f"0x{0:040x}",
+                    caller_address=addresses[0].starknet_address,
+                )
+
+        @pytest.mark.skip("Test fails when address is 2**128 or greater")
+        @pytest.mark.parametrize("address", [2**127, 2**128])
+        async def test_should_not_revert_when_address_is_not_zero(
+            self, plain_opcodes, addresses, address
+        ):
+            await plain_opcodes.requireNotZero(
+                f"0x{address:x}",
+                caller_address=addresses[0].starknet_address,
+            )

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
@@ -357,8 +357,8 @@ class TestPlainOpcodes:
         ):
             salt = 1234
             evm_address = await plain_opcodes.create2(
-                counter.constructor().data_in_transaction,
-                salt,
+                bytecode=counter.constructor().data_in_transaction,
+                salt=salt,
                 caller_address=addresses[0].starknet_address,
             )
             starknet_address = get_starknet_address(salt)


### PR DESCRIPTION
Time spent on this PR: 1 day

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Facing an error when testing Univ2Factory, I have eventually manage to isolate the error case in a `PlainOpcode.sol` test.

The error is illustrated in `class TestRequire` that is currently skipped (see also create issue https://github.com/sayajin-labs/kakarot/issues/439)