### PR TITLE
Bugfix: create2 opcode should use deterministically derived evm contract address

### DIFF
--- a/src/kakarot/accounts/contract/library.cairo
+++ b/src/kakarot/accounts/contract/library.cairo
@@ -68,58 +68,9 @@ namespace ContractAccount {
         return ();
     }
 
-    // TEMPORARY bifurcation of create/create2 as we refactor to their conventions of address construction
-    // @notice This function is a factory to handle salt and registration of EVM<>Starknet binding.
-    // @param salt: The salt for computing the corresponding EVM address
-    func deploy_create{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr,
-        bitwise_ptr: BitwiseBuiltin*,
-    }(salt: felt) -> (evm_contract_address: felt, starknet_contract_address: felt) {
-        alloc_locals;
-
-        // Prepare constructor data
-        let (local calldata: felt*) = alloc();
-        let (kakarot_address) = get_contract_address();
-        assert [calldata] = kakarot_address;
-        assert [calldata + 1] = 0;
-
-        // Deploy contract account with no bytecode
-        let (class_hash) = evm_contract_class_hash.read();
-        let (starknet_contract_address) = deploy_syscall(
-            class_hash=class_hash,
-            contract_address_salt=salt,
-            constructor_calldata_size=2,
-            constructor_calldata=calldata,
-            deploy_from_zero=FALSE,
-        );
-
-        // Generate EVM_contract address from the new cairo contract
-        // TODO: Use RLP to compute proper EVM address, see https://www.evm.codes/#f0
-        let (_, low) = split_felt(starknet_contract_address);
-        local evm_contract_address = 0xAbdE100700000000000000000000000000000000 + low;
-
-        evm_contract_deployed.emit(
-            evm_contract_address=evm_contract_address,
-            starknet_contract_address=starknet_contract_address,
-        );
-
-        // Save address of new contracts
-        let (reg_address) = registry_address.read();
-        IRegistry.set_account_entry(
-            contract_address=reg_address,
-            starknet_contract_address=starknet_contract_address,
-            evm_contract_address=evm_contract_address,
-        );
-
-        return (evm_contract_address, starknet_contract_address);
-    }
-
-    // TEMPORARY bifurcation of create/create2 as we refactor to their conventions of address construction
     // @notice This function is a factory to handle evm contract address and registration of EVM<>Starknet binding in the case of create2.
-    // @param salt: The salt for computing the corresponding EVM address
-    func deploy_create2{
+    // @param evm_contract_address: The computed evm contract address to map deployment to.
+    func deploy{
         syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,

--- a/src/kakarot/constants.cairo
+++ b/src/kakarot/constants.cairo
@@ -29,6 +29,9 @@ func salt() -> (value: felt) {
 namespace Constants {
     // Define constants
 
+    // ADDRESSES
+    const ADDRESS_BYTES_LEN = 20;
+
     // BLOCK
     // CHAIN_ID = KKRT (0x4b4b5254) in ASCII
     const CHAIN_ID = 1263227476;

--- a/src/kakarot/instructions/environmental_information.cairo
+++ b/src/kakarot/instructions/environmental_information.cairo
@@ -17,7 +17,7 @@ from kakarot.execution_context import ExecutionContext
 from kakarot.stack import Stack
 from kakarot.memory import Memory
 from kakarot.constants import native_token_address, registry_address
-from kakarot.interfaces.interfaces import IEth, IRegistry, IEvmContract
+from kakarot.interfaces.interfaces import IEth, IRegistry, IEvmContract, IAccount
 
 // @title Environmental information opcodes.
 // @notice This file contains the functions to execute for environmental information opcodes.
@@ -163,8 +163,9 @@ namespace EnvironmentalInformation {
         alloc_locals;
         // Get caller address.
         let (current_address) = get_caller_address();
-        let caller_address = Helpers.to_uint256(current_address);
-        let stack: model.Stack* = Stack.push(self=ctx.stack, element=caller_address);
+        let (evm_address) = IAccount.get_eth_address(current_address);
+        let evm_address_uint256 = Helpers.to_uint256(evm_address);
+        let stack: model.Stack* = Stack.push(self=ctx.stack, element=evm_address_uint256);
 
         // Update the execution context.
         // Update context stack.

--- a/src/kakarot/instructions/sha3.cairo
+++ b/src/kakarot/instructions/sha3.cairo
@@ -56,13 +56,13 @@ namespace Sha3 {
         );
 
         let (local dest: felt*) = alloc();
-        bytes_to_byte8_little_endian(
+        Helpers.bytes_to_bytes8_little_endian(
             bytes_len=length.low,
             bytes=bigendian_data,
             index=0,
             size=length.low,
-            byte8=0,
-            byte8_shift=0,
+            bytes8=0,
+            bytes8_shift=0,
             dest=dest,
             dest_index=0,
         );
@@ -90,47 +90,5 @@ namespace Sha3 {
         );
 
         return ctx;
-    }
-
-    // TODO: natspec
-    func bytes_to_byte8_little_endian{range_check_ptr}(
-        bytes_len: felt,
-        bytes: felt*,
-        index: felt,
-        size: felt,
-        byte8: felt,
-        byte8_shift: felt,
-        dest: felt*,
-        dest_index: felt,
-    ) {
-        alloc_locals;
-        if (index == size) {
-            return ();
-        }
-
-        local current_byte;
-        let out_of_bound = is_le(a=bytes_len, b=index);
-        if (out_of_bound != FALSE) {
-            current_byte = 0;
-        } else {
-            assert current_byte = [bytes + index];
-        }
-
-        let (bit_shift) = pow(256, byte8_shift);
-
-        let _byte8 = byte8 + bit_shift * current_byte;
-
-        let byte8_full = is_le(a=7, b=byte8_shift);
-        let end_of_loop = is_le(size, index + 1);
-        let write_to_dest = is_le(1, byte8_full + end_of_loop);
-        if (write_to_dest != FALSE) {
-            assert dest[dest_index] = _byte8;
-            return bytes_to_byte8_little_endian(
-                bytes_len, bytes, index + 1, size, 0, 0, dest, dest_index + 1
-            );
-        }
-        return bytes_to_byte8_little_endian(
-            bytes_len, bytes, index + 1, size, _byte8, byte8_shift + 1, dest, dest_index
-        );
     }
 }

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -649,12 +649,7 @@ namespace CreateHelper {
 
             finalize_keccak(keccak_ptr_start=keccak_ptr_start, keccak_ptr_end=keccak_ptr);
         }
-        // this is the equivalent of a slice of the last 20 elements of a byte array
-        // i.e. in python address[-20:]
-        // This will keep the last 20 bytes of the byte array and set the rest of the bytes to 0 (here encoded as a uint256)
-        let mask = Helpers.to_uint256(0xffffffffffffffffffffffffffffffffffffffff);
 
-        // let (create2_address_uint256) = uint256_and(a=create2_hash, b=mask);
         let create2_address = Helpers.keccak_hash_to_evm_contract_address(create2_hash);
         return (create2_address,);
     }

--- a/src/kakarot/interfaces/interfaces.cairo
+++ b/src/kakarot/interfaces/interfaces.cairo
@@ -37,6 +37,12 @@ namespace IEth {
 }
 
 @contract_interface
+namespace IAccount {
+    func get_eth_address() -> (eth_address: felt) {
+    }
+}
+
+@contract_interface
 namespace IEvmContract {
     func bytecode_len() -> (len: felt) {
     }

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -18,6 +18,7 @@ from kakarot.model import model
 from kakarot.memory import Memory
 from kakarot.stack import Stack
 from kakarot.instructions import EVMInstructions
+from kakarot.instructions.system_operations import CreateHelper
 from kakarot.interfaces.interfaces import IRegistry, IEvmContract
 from kakarot.execution_context import ExecutionContext
 from kakarot.constants import (
@@ -191,9 +192,8 @@ namespace Kakarot {
     ) {
         alloc_locals;
         let (current_salt) = salt.read();
-        let (evm_contract_address, starknet_contract_address) = ContractAccount.deploy_create(
-            current_salt
-        );
+        let (evm_contract_address) = CreateHelper.get_create_address(0, current_salt);
+        let (starknet_contract_address) = ContractAccount.deploy(evm_contract_address);
         salt.write(value=current_salt + 1);
 
         // Prepare execution context

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -9,7 +9,7 @@ from starkware.cairo.common.bool import FALSE
 from starkware.cairo.common.math import split_felt
 from starkware.cairo.common.memcpy import memcpy
 from starkware.starknet.common.syscalls import deploy as deploy_syscall
-from starkware.starknet.common.syscalls import get_contract_address
+from starkware.starknet.common.syscalls import get_caller_address, get_contract_address
 // OpenZeppelin dependencies
 from openzeppelin.access.ownable.library import Ownable
 
@@ -19,7 +19,7 @@ from kakarot.memory import Memory
 from kakarot.stack import Stack
 from kakarot.instructions import EVMInstructions
 from kakarot.instructions.system_operations import CreateHelper
-from kakarot.interfaces.interfaces import IRegistry, IEvmContract
+from kakarot.interfaces.interfaces import IRegistry, IAccount, IEvmContract
 from kakarot.execution_context import ExecutionContext
 from kakarot.constants import (
     native_token_address,
@@ -192,7 +192,11 @@ namespace Kakarot {
     ) {
         alloc_locals;
         let (current_salt) = salt.read();
-        let (evm_contract_address) = CreateHelper.get_create_address(0, current_salt);
+        let (current_address) = get_caller_address();
+        let (sender_eth_address) = IAccount.get_eth_address(current_address);
+        let (evm_contract_address) = CreateHelper.get_create_address(
+            sender_eth_address, current_salt
+        );
         let (starknet_contract_address) = ContractAccount.deploy(evm_contract_address);
         salt.write(value=current_salt + 1);
 

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -191,7 +191,7 @@ namespace Kakarot {
     ) {
         alloc_locals;
         let (current_salt) = salt.read();
-        let (evm_contract_address, starknet_contract_address) = ContractAccount.deploy(
+        let (evm_contract_address, starknet_contract_address) = ContractAccount.deploy_create(
             current_salt
         );
         salt.write(value=current_salt + 1);

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -236,6 +236,28 @@ namespace Helpers {
         return (bytes_array_len=32, bytes_array=value_as_bytes_array);
     }
 
+    // @notice This function is like `uint256_to_bytes_array` except it writes the byte array to a given destination with the given offset and length
+    // @param value: value to convert.
+    // @param byte_array_offset: The starting offset of byte array that is copied to the destination array.
+    // @param byte_array_len: The length of byte array that is copied to the destination array.
+    // @param dest_offset: The offset of the destination array that the byte array is copied.
+    // @param dest_len: The length of the destination array.
+    // @param dest: The destination array
+    // @return: array length and felt array representation of the value.
+    func uint256_to_dest_bytes_array{range_check_ptr}(
+        value: Uint256,
+        byte_array_offset: felt,
+        byte_array_len: felt,
+        dest_offset: felt,
+        dest_len: felt,
+        dest: felt*,
+    ) -> (updated_dest_len: felt) {
+        alloc_locals;
+        let (_, bytes_array) = uint256_to_bytes_array(value);
+        memcpy(dst=dest + dest_offset, src=bytes_array + byte_array_offset, len=byte_array_len);
+        return (updated_dest_len=dest_len + byte_array_len);
+    }
+
     // @notice Loads a sequence of bytes into a single felt in big-endian.
     // @param len: number of bytes.
     // @param ptr: pointer to bytes array.
@@ -634,7 +656,7 @@ namespace Helpers {
     }
 
     // @notice transform muliple bytes into a single felt
-    // @param data_len The lenght of the bytes
+    // @param data_len The length of the bytes
     // @param data The pointer to the bytes array
     // @param n used for recursion, set to 0
     // @return n the resultant felt
@@ -646,5 +668,14 @@ namespace Helpers {
         let byte: felt = data[data_len - 1];
         let (res) = pow(256, e);
         return bytes_to_felt(data_len=data_len - 1, data=data, n=n + byte * res);
+    }
+
+    // @notice Transforms a keccak hash to an ethereum address by taking last 20 bytes
+    // @param hash - The keccak hash.
+    // @return address - The address.
+    func keccak_hash_to_evm_contract_address{range_check_ptr}(hash: Uint256) -> felt {
+        let (_, r) = unsigned_div_rem(hash.high, 256 ** 4);
+        let address = hash.low + r * 2 ** 128;
+        return address;
     }
 }

--- a/tests/integration/bytecode/test_cases.py
+++ b/tests/integration/bytecode/test_cases.py
@@ -772,7 +772,7 @@ test_cases = [
             "value": 0,
             "code": "3300",
             "calldata": "",
-            "stack": "1",
+            "stack": "552990106838132297007705540970627247012975398931",
             "memory": "",
             "return_value": "",
         },

--- a/tests/integration/bytecode/test_kakarot.py
+++ b/tests/integration/bytecode/test_kakarot.py
@@ -18,7 +18,9 @@ class TestKakarot:
         "params",
         params_execute,
     )
-    async def test_execute(self, kakarot: StarknetContract, owner, params: dict, request):
+    async def test_execute(
+        self, kakarot: StarknetContract, owner, params: dict, request
+    ):
         with traceit.context(request.node.callspec.id):
             res = await kakarot.execute(
                 value=int(params["value"]),

--- a/tests/integration/bytecode/test_kakarot.py
+++ b/tests/integration/bytecode/test_kakarot.py
@@ -18,13 +18,13 @@ class TestKakarot:
         "params",
         params_execute,
     )
-    async def test_execute(self, kakarot: StarknetContract, params: dict, request):
+    async def test_execute(self, kakarot: StarknetContract, owner, params: dict, request):
         with traceit.context(request.node.callspec.id):
             res = await kakarot.execute(
                 value=int(params["value"]),
                 bytecode=hex_string_to_bytes_array(params["code"]),
                 calldata=hex_string_to_bytes_array(params["calldata"]),
-            ).call(caller_address=1)
+            ).call(caller_address=owner.starknet_address)
 
         stack_result = extract_stack_from_execute(res.result)
         memory_result = extract_memory_from_execute(res.result)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -152,10 +152,11 @@ async def addresses(deployer, starknet, externally_owned_account_class) -> List[
                     eth_aa_deploy_tx.call_info.internal_calls[0].contract_address,
                     eth_aa_deploy_tx,
                 ),
-                starknet_address=int(private_key.public_key.to_address(), 16),
+                starknet_address=eth_aa_deploy_tx.call_info.internal_calls[
+                    0
+                ].contract_address,
             )
         )
-
     return wallets
 
 

--- a/tests/integration/helpers/helpers.py
+++ b/tests/integration/helpers/helpers.py
@@ -4,7 +4,7 @@ from typing import Tuple
 
 from eth_abi import encode_abi
 from eth_keys import keys
-from eth_utils import keccak, to_bytes, to_checksum_address
+from eth_utils import decode_hex, keccak, to_checksum_address
 
 from tests.integration.helpers.constants import CHAIN_ID
 
@@ -80,10 +80,7 @@ def get_create2_address(
     """
     return to_checksum_address(
         keccak(
-            b"\xff"
-            + to_bytes(hexstr=sender_address)
-            + salt
-            + keccak(initialization_code)
+            b"\xff" + decode_hex(sender_address) + salt + keccak(initialization_code)
         )[-20:]
     )
 

--- a/tests/integration/helpers/helpers.py
+++ b/tests/integration/helpers/helpers.py
@@ -4,7 +4,7 @@ from typing import Tuple
 
 from eth_abi import encode_abi
 from eth_keys import keys
-from eth_utils import decode_hex, keccak, to_checksum_address
+from eth_utils import keccak, to_bytes, to_checksum_address
 
 from tests.integration.helpers.constants import CHAIN_ID
 
@@ -80,7 +80,10 @@ def get_create2_address(
     """
     return to_checksum_address(
         keccak(
-            b"\xff" + decode_hex(sender_address) + salt + keccak(initialization_code)
+            b"\xff"
+            + to_bytes(hexstr=sender_address)
+            + salt
+            + keccak(initialization_code)
         )[-20:]
     )
 

--- a/tests/unit/helpers/helpers.cairo
+++ b/tests/unit/helpers/helpers.cairo
@@ -51,6 +51,39 @@ namespace TestHelpers {
         return ctx;
     }
 
+    func init_context_at_address_with_stack{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr,
+        bitwise_ptr: BitwiseBuiltin*,
+    }(
+        address: felt, bytecode_len: felt, bytecode: felt*, stack: model.Stack*
+    ) -> model.ExecutionContext* {
+        alloc_locals;
+
+        let self: model.ExecutionContext* = init_context_with_stack(bytecode_len, bytecode, stack);
+
+        return new model.ExecutionContext(
+            call_context=self.call_context,
+            program_counter=self.program_counter,
+            stopped=self.stopped,
+            return_data=self.return_data,
+            return_data_len=self.return_data_len,
+            stack=self.stack,
+            memory=self.memory,
+            gas_used=self.gas_used,
+            gas_limit=self.gas_limit,
+            gas_price=self.gas_price,
+            starknet_contract_address=self.starknet_contract_address,
+            evm_contract_address=address,
+            calling_context=self.calling_context,
+            sub_context=self.sub_context,
+            destroy_contracts_len=self.destroy_contracts_len,
+            destroy_contracts=self.destroy_contracts,
+            read_only=self.read_only,
+            );
+    }
+
     // @notice Init an execution context where bytecode has "bytecode_count" entries of "value".
     func init_context_with_bytecode{
         syscall_ptr: felt*,

--- a/tests/unit/src/kakarot/instructions/test_system_operations.cairo
+++ b/tests/unit/src/kakarot/instructions/test_system_operations.cairo
@@ -96,9 +96,9 @@ func test__exec_call__should_return_a_new_context_based_on_calling_ctx_stack{
     local bytecode_len = 0;
     evm_contract_class_hash.write(evm_contract_class_hash_);
     registry_address.write(registry_address_);
-    let (
-        local evm_contract_address, local starknet_contract_address
-    ) = ContractAccount.deploy_create(0);
+
+    let (evm_contract_address) = CreateHelper.get_create_address(0, 0);
+    let (local starknet_contract_address) = ContractAccount.deploy(evm_contract_address);
 
     // Fill the stack with input data
     let stack: model.Stack* = Stack.init();
@@ -175,9 +175,9 @@ func test__exec_callcode__should_return_a_new_context_based_on_calling_ctx_stack
     local bytecode_len = 0;
     evm_contract_class_hash.write(evm_contract_class_hash_);
     registry_address.write(registry_address_);
-    let (
-        local evm_contract_address, local starknet_contract_address
-    ) = ContractAccount.deploy_create(0);
+
+    let (evm_contract_address) = CreateHelper.get_create_address(0, 0);
+    let (local starknet_contract_address) = ContractAccount.deploy(evm_contract_address);
 
     // Fill the stack with input data
     let stack: model.Stack* = Stack.init();
@@ -254,9 +254,9 @@ func test__exec_staticcall__should_return_a_new_context_based_on_calling_ctx_sta
     local bytecode_len = 0;
     evm_contract_class_hash.write(evm_contract_class_hash_);
     registry_address.write(registry_address_);
-    let (
-        local evm_contract_address, local starknet_contract_address
-    ) = ContractAccount.deploy_create(0);
+
+    let (evm_contract_address) = CreateHelper.get_create_address(0, 0);
+    let (local starknet_contract_address) = ContractAccount.deploy(evm_contract_address);
 
     // Fill the stack with input data
     let stack: model.Stack* = Stack.init();
@@ -331,9 +331,9 @@ func test__exec_delegatecall__should_return_a_new_context_based_on_calling_ctx_s
     local bytecode_len = 0;
     evm_contract_class_hash.write(evm_contract_class_hash_);
     registry_address.write(registry_address_);
-    let (
-        local evm_contract_address, local starknet_contract_address
-    ) = ContractAccount.deploy_create(0);
+
+    let (evm_contract_address) = CreateHelper.get_create_address(0, 0);
+    let (local starknet_contract_address) = ContractAccount.deploy(evm_contract_address);
 
     // Fill the stack with input data
     let stack: model.Stack* = Stack.init();
@@ -612,7 +612,8 @@ func test__exec_selfdestruct__should_delete_account_bytecode{
     assert [sub_ctx + 16] = 0;  // read only
 
     // Simulate contract creation
-    let (evm_contract_address, starknet_contract_address) = ContractAccount.deploy_create(0);
+    let (evm_contract_address) = CreateHelper.get_create_address(0, 0);
+    let (local starknet_contract_address) = ContractAccount.deploy(evm_contract_address);
 
     IRegistry.set_account_entry(
         contract_address=registry_address_,

--- a/tests/unit/src/kakarot/instructions/test_system_operations.py
+++ b/tests/unit/src/kakarot/instructions/test_system_operations.py
@@ -85,9 +85,8 @@ class TestSystemOperations:
         # we store a memory word in memory
         # and have our bytecode as the memory read from an offset and size
         # we take that word at an offset and size and use it as the bytecode to determine the expected create2 evm contract address
-        # Word is 0x 11 22 33 44 55 66 77 88 00 00 ... 00
         # bytecode should be 0x 44 55 66 77
-        memory_word = 22774453838368691922685013100469420032
+        memory_word = 0x11223344556677880000000000000000
         offset = 3
         size = 4
         salt = 5

--- a/tests/unit/src/kakarot/instructions/test_system_operations.py
+++ b/tests/unit/src/kakarot/instructions/test_system_operations.py
@@ -2,14 +2,14 @@ import string
 
 import pytest
 import pytest_asyncio
-from eth_utils import decode_hex, to_bytes
+from eth_utils import decode_hex, to_bytes, to_checksum_address
 from starkware.python.utils import from_bytes
 from starkware.starknet.testing.contract import StarknetContract
 from starkware.starknet.testing.starknet import Starknet
 
 from tests.integration.helpers.helpers import get_create2_address
 from tests.utils.errors import kakarot_error
-from tests.utils.uint256 import int_to_uint256, uint256_to_int
+from tests.utils.uint256 import int_to_uint256
 
 
 @pytest_asyncio.fixture(scope="module")
@@ -87,32 +87,28 @@ class TestSystemOperations:
         # we take that word at an offset and size and use it as the bytecode to determine the expected create2 evm contract address
         # Word is 0x 11 22 33 44 55 66 77 88 00 00 ... 00
         # bytecode should be 0x 44 55 66 77
-        memory_word_uint256 = (0, 22774453838368691922685013100469420032)
+        memory_word = 22774453838368691922685013100469420032
         offset = 3
         size = 4
         salt = 5
         padded_salt = salt.to_bytes(32, byteorder="big")
-        evm_caller_address = 15
-        bytecode = to_bytes(
-            uint256_to_int(memory_word_uint256[0], memory_word_uint256[1])
-        )[offset : offset + size]
+        evm_caller_address_int = 15
+        evm_caller_address_bytes = evm_caller_address_int.to_bytes(20, byteorder="big")
+        evm_caller_address = to_checksum_address(evm_caller_address_bytes)
+        bytecode = to_bytes(memory_word)[offset : offset + size]
 
         expected_create2_addr = get_create2_address(
-            hex(evm_caller_address), padded_salt, bytecode
+            evm_caller_address, padded_salt, bytecode
         )
-
-        expected_create2_addr2 = create2_address(
-            evm_caller_address, bytecode, padded_salt
-        )[20:]
 
         await system_operations.test__exec_create2__should_return_a_new_context_with_bytecode_from_memory_at_expected_address(
             contract_account_class.class_hash,
             account_registry.contract_address,
-            evm_caller_address,
+            evm_caller_address_int,
             (offset, 0),
             (size, 0),
             (salt, 0),
-            memory_word_uint256,
+            (0, memory_word),
             from_bytes(decode_hex(expected_create2_addr)),
         ).call()
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 1.75 days

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The EVM address of a contract account is computed as follows:

```
        // Generate EVM_contract address from the new cairo contract
        // TODO: Use RLP to compute proper EVM address, see https://www.evm.codes/#f0
        let (_, low) = split_felt(starknet_contract_address);
        local evm_contract_address = 0xAbdE100700000000000000000000000000000000 + low;
```

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves #427 

also resolves #426 wrt create2 opcode

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
Create2's address is defined via
```
address = keccak256(0xff + sender_address + salt + keccak256(initialisation_code))[12:]
```
-
-
-

## Other information

There is a current temporary split in deploy code, where create2 logic is handled separately from create. When both construct their address deterministically, the temporary refactor will be removed.
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
