### PR TITLE
[Fix] Generate 20 bytes instead of a uint160 in Univ2Factory test

### DIFF
--- a/tests/integration/solidity_contracts/UniswapV2/test_uniswap_v2_factory.py
+++ b/tests/integration/solidity_contracts/UniswapV2/test_uniswap_v2_factory.py
@@ -1,3 +1,4 @@
+import os
 import random
 from typing import Callable
 
@@ -10,9 +11,8 @@ from tests.utils.errors import kakarot_error
 
 # TODO: Fix these addresses with the original ones once
 # TODO: https://github.com/sayajin-labs/kakarot/issues/439 is fixed
-TEST_ADDRESSES = [
-    to_checksum_address(f"{random.randint(0, 2**160):x}") for _ in range(2)
-]
+random.seed(0)
+TEST_ADDRESSES = [to_checksum_address(os.urandom(20)) for _ in range(2)]
 
 
 @pytest_asyncio.fixture(scope="module")


### PR DESCRIPTION
Time spent on this PR: 0.5

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Random addresses are generated without setting the seed
These addresses may have a leading `0` nibble in bytes representation which breaks the `to_checksum_address`

## What is the new behavior?

Set seed
Generate 20 random bytes instead of a uint160.
