### PR TITLE
fix: change RNG to allow seeding

### DIFF
--- a/tests/integration/solidity_contracts/UniswapV2/test_uniswap_v2_factory.py
+++ b/tests/integration/solidity_contracts/UniswapV2/test_uniswap_v2_factory.py
@@ -1,4 +1,3 @@
-import os
 import random
 from typing import Callable
 
@@ -12,7 +11,7 @@ from tests.utils.errors import kakarot_error
 # TODO: Fix these addresses with the original ones once
 # TODO: https://github.com/sayajin-labs/kakarot/issues/439 is fixed
 random.seed(0)
-TEST_ADDRESSES = [to_checksum_address(os.urandom(20)) for _ in range(2)]
+TEST_ADDRESSES = [to_checksum_address(random.getrandbits(160)) for _ in range(2)]
 
 
 @pytest_asyncio.fixture(scope="module")


### PR DESCRIPTION
Time spent on this PR: 0.2 days

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Random bytes drawing for TEST_ADDRESSES is not seedable.

## What is the new behavior?

The TEST_ADDRESSES are deterministically generated.