### PR TITLE
fix: RETURNDATACOPY fails in PlainOpcode test #446

### DIFF
--- a/src/kakarot/instructions/environmental_information.cairo
+++ b/src/kakarot/instructions/environmental_information.cairo
@@ -653,8 +653,7 @@ namespace EnvironmentalInformation {
         let element_len = popped[2];
 
         let return_data_len: felt = ctx.sub_context.return_data_len;
-        // Note: +1 see the CALL opcode: the return_data[0] stores the ret_offset in memory
-        let return_data: felt* = ctx.sub_context.return_data + 1;
+        let return_data: felt* = ctx.sub_context.return_data;
 
         let sliced_return_data: felt* = Helpers.slice_data(
             data_len=return_data_len,

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
@@ -178,8 +178,10 @@ class TestPlainOpcodes:
             assert origin == sender == owner.address
 
         @pytest.mark.skip(
-            "Raises in RETURNDATACOPY"
-            "See issue https://github.com/sayajin-labs/kakarot/issues/446"
+            "ORIGIN returns address(0)"
+            "See issue https://github.com/sayajin-labs/kakarot/issues/445"
+            # "Raises in RETURNDATACOPY"
+            # "See issue https://github.com/sayajin-labs/kakarot/issues/446"
         )
         async def test_should_return_owner_as_origin_and_caller_as_sender(
             self, plain_opcodes, owner, caller
@@ -190,3 +192,6 @@ class TestPlainOpcodes:
                 caller_address=owner.starknet_address,
             )
             assert success
+            decoded = Web3().codec.decode(['address', 'address'], data)
+            assert owner.address == decoded[0] #tx.origin
+            assert caller.evm_contract_address == decoded[1] #msg.sender

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
@@ -180,8 +180,6 @@ class TestPlainOpcodes:
         @pytest.mark.skip(
             "ORIGIN returns address(0)"
             "See issue https://github.com/sayajin-labs/kakarot/issues/445"
-            # "Raises in RETURNDATACOPY"
-            # "See issue https://github.com/sayajin-labs/kakarot/issues/446"
         )
         async def test_should_return_owner_as_origin_and_caller_as_sender(
             self, plain_opcodes, owner, caller

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
@@ -192,6 +192,6 @@ class TestPlainOpcodes:
                 caller_address=owner.starknet_address,
             )
             assert success
-            decoded = Web3().codec.decode(['address', 'address'], data)
-            assert owner.address == decoded[0] #tx.origin
-            assert caller.evm_contract_address == decoded[1] #msg.sender
+            decoded = Web3().codec.decode(["address", "address"], data)
+            assert owner.address == decoded[0]  # tx.origin
+            assert caller.evm_contract_address == decoded[1]  # msg.sender

--- a/tests/unit/src/kakarot/instructions/test_environmental_information.cairo
+++ b/tests/unit/src/kakarot/instructions/test_environmental_information.cairo
@@ -248,7 +248,7 @@ func test__returndatacopy{
     let (bytecode) = alloc();
     let (return_data) = alloc();
     let return_data_len: felt = 32;
-    
+
     TestHelpers.array_fill(return_data, return_data_len, 0xFF);
     let child_ctx: model.ExecutionContext* = TestHelpers.init_context_with_return_data(
         0, bytecode, return_data_len, return_data

--- a/tests/unit/src/kakarot/instructions/test_environmental_information.cairo
+++ b/tests/unit/src/kakarot/instructions/test_environmental_information.cairo
@@ -248,8 +248,8 @@ func test__returndatacopy{
     let (bytecode) = alloc();
     let (return_data) = alloc();
     let return_data_len: felt = 32;
-    // filling at return_data + 1 because first first felt is return_data offset
-    TestHelpers.array_fill(return_data + 1, return_data_len, 0xFF);
+    
+    TestHelpers.array_fill(return_data, return_data_len, 0xFF);
     let child_ctx: model.ExecutionContext* = TestHelpers.init_context_with_return_data(
         0, bytecode, return_data_len, return_data
     );


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 3 HRS

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves #446 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `RETURNDATACOPY` in PlainOpcode test doesn't fail
- Updated `test_should_return_owner_as_origin_and_caller_as_sender` test to check returned values
- `test_should_return_owner_as_origin_and_caller_as_sender` is still skipped as it requires #445 to be merged

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
