### PR TITLE
create opcode uses deterministic evm contract address

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1194,7 +1194,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9,<3.10"
-content-hash = "e3d3be35d1d85175a16a7c5fdd2dc103d75a8bfcc81bd575ddbf6547e832678a"
+content-hash = "7dad055d85ea6b3ea1af2693572d5d9c3bb0ca649ff43f539a7769e7cbe430bc"
 
 [metadata.files]
 aiohttp = [
@@ -1646,8 +1646,11 @@ fastecdsa = [
     {file = "fastecdsa-2.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:c72f8f13160798b431c8a772e4e4bce39adf6faeea80fbf75f88010d0b304aa1"},
     {file = "fastecdsa-2.3.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b943a1ad3e1e306f0df422b198f544d029a70f19581e5b56a36ddfbe6302a33d"},
     {file = "fastecdsa-2.3.0-cp37-cp37m-macosx_12_0_arm64.whl", hash = "sha256:82985e09b299ba400f1a21f2872dcc8e659bc127286f026d01b3540853298f9c"},
+    {file = "fastecdsa-2.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:8011db68e65b747b11ffa9575dc5bc6ad6d02aa971054e952e261694f705845a"},
     {file = "fastecdsa-2.3.0-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:fd61e461389a4fc1e965a1bbd5efb77588a0ebae2328aecdf011a5e9d439ce66"},
+    {file = "fastecdsa-2.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:b0a4637e99cc22b5107d32ae001c2e36a5821c7a50ac001b806d64c157bf62c0"},
     {file = "fastecdsa-2.3.0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:7b91663b36137454299d7487a7a1b4a345120bd098ab5f7d7b0a02b50d6c9706"},
+    {file = "fastecdsa-2.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:e45be9bcd063362576f93b344e032c743572c2a9ca7426eea3e4035ba21b1654"},
     {file = "fastecdsa-2.3.0.tar.gz", hash = "sha256:6c59aba650862a59f601ff7f66cd6712f4798ae68907c953d58417a5887103de"},
 ]
 frozendict = [
@@ -2247,6 +2250,18 @@ setproctitle = [
     {file = "setproctitle-1.3.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7f2719a398e1a2c01c2a63bf30377a34d0b6ef61946ab9cf4d550733af8f1ef1"},
     {file = "setproctitle-1.3.2-cp310-cp310-win32.whl", hash = "sha256:e425be62524dc0c593985da794ee73eb8a17abb10fe692ee43bb39e201d7a099"},
     {file = "setproctitle-1.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:e85e50b9c67854f89635a86247412f3ad66b132a4d8534ac017547197c88f27d"},
+    {file = "setproctitle-1.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2a97d51c17d438cf5be284775a322d57b7ca9505bb7e118c28b1824ecaf8aeaa"},
+    {file = "setproctitle-1.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:587c7d6780109fbd8a627758063d08ab0421377c0853780e5c356873cdf0f077"},
+    {file = "setproctitle-1.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7d17c8bd073cbf8d141993db45145a70b307385b69171d6b54bcf23e5d644de"},
+    {file = "setproctitle-1.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e932089c35a396dc31a5a1fc49889dd559548d14cb2237adae260382a090382e"},
+    {file = "setproctitle-1.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8e4f8f12258a8739c565292a551c3db62cca4ed4f6b6126664e2381acb4931bf"},
+    {file = "setproctitle-1.3.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:570d255fd99c7f14d8f91363c3ea96bd54f8742275796bca67e1414aeca7d8c3"},
+    {file = "setproctitle-1.3.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a8e0881568c5e6beff91ef73c0ec8ac2a9d3ecc9edd6bd83c31ca34f770910c4"},
+    {file = "setproctitle-1.3.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:4bba3be4c1fabf170595b71f3af46c6d482fbe7d9e0563999b49999a31876f77"},
+    {file = "setproctitle-1.3.2-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:37ece938110cab2bb3957e3910af8152ca15f2b6efdf4f2612e3f6b7e5459b80"},
+    {file = "setproctitle-1.3.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:db684d6bbb735a80bcbc3737856385b55d53f8a44ce9b46e9a5682c5133a9bf7"},
+    {file = "setproctitle-1.3.2-cp311-cp311-win32.whl", hash = "sha256:ca58cd260ea02759238d994cfae844fc8b1e206c684beb8f38877dcab8451dfc"},
+    {file = "setproctitle-1.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:88486e6cce2a18a033013d17b30a594f1c5cb42520c49c19e6ade40b864bb7ff"},
     {file = "setproctitle-1.3.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:92c626edc66169a1b09e9541b9c0c9f10488447d8a2b1d87c8f0672e771bc927"},
     {file = "setproctitle-1.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:710e16fa3bade3b026907e4a5e841124983620046166f355bbb84be364bf2a02"},
     {file = "setproctitle-1.3.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f29b75e86260b0ab59adb12661ef9f113d2f93a59951373eb6d68a852b13e83"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ eth-account = "<0.8.0"
 eth-keys = "<0.4.0"
 autoflake = "^2.0.0"
 pycryptodome = "^3.16.0"
+rlp = "<3"
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -10,7 +10,7 @@ from starkware.cairo.common.cairo_keccak.keccak import keccak_bigend, finalize_k
 from starkware.cairo.common.math import split_felt
 from starkware.cairo.common.math_cmp import is_le, is_not_zero, is_nn
 from starkware.cairo.common.memcpy import memcpy
-from starkware.cairo.common.uint256 import Uint256, uint256_and
+from starkware.cairo.common.uint256 import Uint256
 from starkware.starknet.common.syscalls import deploy as deploy_syscall
 from starkware.starknet.common.syscalls import get_contract_address
 
@@ -29,6 +29,7 @@ from kakarot.interfaces.interfaces import IEvmContract, IRegistry, IEth
 from kakarot.memory import Memory
 from kakarot.model import model
 from kakarot.stack import Stack
+from utils.rlp import RLP
 from utils.utils import Helpers
 
 // @title System operations opcodes.
@@ -551,9 +552,58 @@ namespace CreateHelper {
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
-    }(sender_address: felt, nonce: felt) -> (evm_contract_address: felt) {
-        // TODO: see https://github.com/sayajin-labs/kakarot/issues/426
-        return (0xAbdE100700000000000000000000000000000000 + nonce,);
+    }(sender_address: felt, salt: felt) -> (evm_contract_address: felt) {
+        alloc_locals;
+        let (keccak_ptr: felt*) = alloc();
+        local keccak_ptr_start: felt* = keccak_ptr;
+
+        let (local address_packed_bytes: felt*) = alloc();
+
+        // pack sender address, padded twenty bytes
+        // the address should be twenty bytes, so we skip the leading 12 elements
+        let (sender_address_high, sender_address_low) = split_felt(sender_address);
+
+        let (address_packed_bytes_len) = Helpers.uint256_to_dest_bytes_array(
+            value=Uint256(low=sender_address_low, high=sender_address_high),
+            byte_array_offset=12,
+            byte_array_len=Constants.ADDRESS_BYTES_LEN,
+            dest_offset=0,
+            dest_len=0,
+            dest=address_packed_bytes,
+        );
+
+        // encode address rlp
+        let (local packed_bytes: felt*) = alloc();
+        let (packed_bytes_len) = RLP.encode_element_byte_array(
+            address_packed_bytes_len, address_packed_bytes, 0, packed_bytes
+        );
+
+        // encode salt rlp
+        let (packed_bytes_len) = RLP.encode_element_felt(salt, packed_bytes_len, packed_bytes);
+
+        let (local rlp_list: felt*) = alloc();
+        let (rlp_list_len: felt) = RLP.encode_rlp_list(packed_bytes_len, packed_bytes, rlp_list);
+
+        let (local packed_bytes8: felt*) = alloc();
+        Helpers.bytes_to_bytes8_little_endian(
+            bytes_len=rlp_list_len,
+            bytes=rlp_list,
+            index=0,
+            size=rlp_list_len,
+            bytes8=0,
+            bytes8_shift=0,
+            dest=packed_bytes8,
+            dest_index=0,
+        );
+
+        with keccak_ptr {
+            let (create_hash) = keccak_bigend(inputs=packed_bytes8, n_bytes=rlp_list_len);
+
+            finalize_keccak(keccak_ptr_start=keccak_ptr_start, keccak_ptr_end=keccak_ptr);
+        }
+
+        let create_address = Helpers.keccak_hash_to_evm_contract_address(create_hash);
+        return (create_address,);
     }
 
     // @notice Constructs an evm contract address for the create2 opcode

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -574,12 +574,12 @@ namespace CreateHelper {
 
         // encode address rlp
         let (local packed_bytes: felt*) = alloc();
-        let (packed_bytes_len) = RLP.encode_element_byte_array(
+        let (packed_bytes_len) = RLP.encode_byte_array(
             address_packed_bytes_len, address_packed_bytes, 0, packed_bytes
         );
 
         // encode salt rlp
-        let (packed_bytes_len) = RLP.encode_element_felt(salt, packed_bytes_len, packed_bytes);
+        let (packed_bytes_len) = RLP.encode_felt(salt, packed_bytes_len, packed_bytes);
 
         let (local rlp_list: felt*) = alloc();
         let (rlp_list_len: felt) = RLP.encode_rlp_list(packed_bytes_len, packed_bytes, rlp_list);

--- a/src/utils/rlp.cairo
+++ b/src/utils/rlp.cairo
@@ -142,40 +142,40 @@ namespace RLP {
         }
     }
 
-    // @notice encodes felt into an rlp element
-    // @param element The felt that is encoded into rlp
+    // @notice encodes felt into an rlp item
+    // @param item The felt that is encoded into rlp
     // @param rlp_len The length of the rlp array
     // @param rlp The pointer receiving the rlp encoded felt
     // @return rlp_len The length of the encoded felt in bytes
-    func encode_element_felt{
+    func encode_felt{
         syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         bitwise_ptr: BitwiseBuiltin*,
         range_check_ptr,
-    }(element: felt, rlp_len: felt, rlp: felt*) -> (rlp_len: felt) {
+    }(item: felt, rlp_len: felt, rlp: felt*) -> (rlp_len: felt) {
         alloc_locals;
         // 127 is the largest value that can be represented by one byte
-        let element_is_single_byte = is_le(element, 127);
+        let item_is_single_byte = is_le(item, 127);
 
-        if (element_is_single_byte != FALSE) {
+        if (item_is_single_byte != FALSE) {
             // single byte needs no prefix
-            assert [rlp + rlp_len] = element;
+            assert [rlp + rlp_len] = item;
             return (rlp_len + 1,);
         } else {
             // otherwise, we need to convert the value to an unpadded byte array
-            let (local reversed_element_bytes: felt*) = alloc();
-            let (local element_bytes: felt*) = alloc();
+            let (local reversed_item_bytes: felt*) = alloc();
+            let (local item_bytes: felt*) = alloc();
 
-            let (element_high, element_low) = split_felt(element);
-            let (element_bytes_len) = Helpers.uint256_to_bytes_no_padding(
-                Uint256(low=element_low, high=element_high),
+            let (item_high, item_low) = split_felt(item);
+            let (item_bytes_len) = Helpers.uint256_to_bytes_no_padding(
+                Uint256(low=item_low, high=item_high),
                 0,
-                reversed_element_bytes,
-                element_bytes,
+                reversed_item_bytes,
+                item_bytes,
             );
 
-            let (updated_rlp_len) = encode_element_byte_array(
-                element_bytes_len, element_bytes, rlp_len, rlp
+            let (updated_rlp_len) = encode_byte_array(
+                item_bytes_len, item_bytes, rlp_len, rlp
             );
             return (updated_rlp_len,);
         }
@@ -186,7 +186,7 @@ namespace RLP {
     // @param byte_array The pointer to the first byte in the array to copy from
     // @param rlp The pointer receiving the rlp encoded list
     // @return rlp_len The length of the encoded list in bytes
-    func encode_element_byte_array{
+    func encode_byte_array{
         syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         bitwise_ptr: BitwiseBuiltin*,
@@ -194,9 +194,9 @@ namespace RLP {
     }(byte_array_len, byte_array: felt*, rlp_len: felt, rlp: felt*) -> (rlp_len: felt) {
         alloc_locals;
 
-        let element_is_le_55 = is_le(byte_array_len, 55);
+        let item_len_is_le_55 = is_le(byte_array_len, 55);
 
-        if (element_is_le_55 != FALSE) {
+        if (item_len_is_le_55 != FALSE) {
             // when the bytes array length is less than 55 bytes, we encode it with a single prefix
             assert [rlp + rlp_len] = 0x80 + byte_array_len;
             Helpers.fill_array(byte_array_len, byte_array, rlp + rlp_len + 1);
@@ -205,22 +205,22 @@ namespace RLP {
             // otherwise we encode in a prefix
             // the length
             // of
-            // the value of the length of elements byte representation
-            // then the actual length of the elements of the bytes representation
+            // the value of the length of item's byte representation
+            // then the actual length of the the bytes representation of item
             // then the element bytes (phew)
-            let (local element_len_bytes: felt*) = alloc();
-            // note the subtle shift of terms: we are taking the value of the length of bytes of the element and converting it to bytes!
-            let (element_len_bytes_len) = Helpers.felt_to_bytes(
-                byte_array_len, 0, element_len_bytes
+            let (local item_len_bytes: felt*) = alloc();
+            // note the subtle shift of terms: we are taking the value of the length of bytes of the item and converting it to bytes!
+            let (item_len_bytes_len) = Helpers.felt_to_bytes(
+                byte_array_len, 0, item_len_bytes
             );
-            assert [rlp + rlp_len] = 0xb7 + element_len_bytes_len;
-            Helpers.fill_array(element_len_bytes_len, element_len_bytes, rlp + rlp_len + 1);
+            assert [rlp + rlp_len] = 0xb7 + item_len_bytes_len;
+            Helpers.fill_array(item_len_bytes_len, item_len_bytes, rlp + rlp_len + 1);
 
             Helpers.fill_array(
-                byte_array_len, byte_array, rlp + rlp_len + 1 + element_len_bytes_len
+                byte_array_len, byte_array, rlp + rlp_len + 1 + item_len_bytes_len
             );
 
-            return (rlp_len + element_len_bytes_len + byte_array_len + 1,);
+            return (rlp_len + item_len_bytes_len + byte_array_len + 1,);
         }
     }
 }

--- a/src/utils/rlp.cairo
+++ b/src/utils/rlp.cairo
@@ -3,9 +3,10 @@
 %lang starknet
 
 from starkware.cairo.common.bool import TRUE, FALSE
+from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.math_cmp import is_le
-from starkware.cairo.common.math import assert_le
+from starkware.cairo.common.math import assert_le, split_felt
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.pow import pow
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
@@ -138,6 +139,88 @@ namespace RLP {
             Helpers.fill_array(bytes_len, bytes, rlp + 1);
             Helpers.fill_array(data_len, data, rlp + 1 + bytes_len);
             return (rlp_len=data_len + 1);
+        }
+    }
+
+    // @notice encodes felt into an rlp element
+    // @param element The felt that is encoded into rlp
+    // @param rlp_len The length of the rlp array
+    // @param rlp The pointer receiving the rlp encoded felt
+    // @return rlp_len The length of the encoded felt in bytes
+    func encode_element_felt{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        bitwise_ptr: BitwiseBuiltin*,
+        range_check_ptr,
+    }(element: felt, rlp_len: felt, rlp: felt*) -> (rlp_len: felt) {
+        alloc_locals;
+        // 127 is the largest value that can be represented by one byte
+        let element_is_single_byte = is_le(element, 127);
+
+        if (element_is_single_byte != FALSE) {
+            // single byte needs no prefix
+            assert [rlp + rlp_len] = element;
+            return (rlp_len + 1,);
+        } else {
+            // otherwise, we need to convert the value to an unpadded byte array
+            let (local reversed_element_bytes: felt*) = alloc();
+            let (local element_bytes: felt*) = alloc();
+
+            let (element_high, element_low) = split_felt(element);
+            let (element_bytes_len) = Helpers.uint256_to_bytes_no_padding(
+                Uint256(low=element_low, high=element_high),
+                0,
+                reversed_element_bytes,
+                element_bytes,
+            );
+
+            let (updated_rlp_len) = encode_element_byte_array(
+                element_bytes_len, element_bytes, rlp_len, rlp
+            );
+            return (updated_rlp_len,);
+        }
+    }
+
+    // @notice encodes byte array into an rlp element
+    // @param byte_array_len The length of the bytes to copy from
+    // @param byte_array The pointer to the first byte in the array to copy from
+    // @param rlp The pointer receiving the rlp encoded list
+    // @return rlp_len The length of the encoded list in bytes
+    func encode_element_byte_array{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        bitwise_ptr: BitwiseBuiltin*,
+        range_check_ptr,
+    }(byte_array_len, byte_array: felt*, rlp_len: felt, rlp: felt*) -> (rlp_len: felt) {
+        alloc_locals;
+
+        let element_is_le_55 = is_le(byte_array_len, 55);
+
+        if (element_is_le_55 != FALSE) {
+            // when the bytes array length is less than 55 bytes, we encode it with a single prefix
+            assert [rlp + rlp_len] = 0x80 + byte_array_len;
+            Helpers.fill_array(byte_array_len, byte_array, rlp + rlp_len + 1);
+            return (rlp_len + byte_array_len + 1,);
+        } else {
+            // otherwise we encode in a prefix
+            // the length
+            // of
+            // the value of the length of elements byte representation
+            // then the actual length of the elements of the bytes representation
+            // then the element bytes (phew)
+            let (local element_len_bytes: felt*) = alloc();
+            // note the subtle shift of terms: we are taking the value of the length of bytes of the element and converting it to bytes!
+            let (element_len_bytes_len) = Helpers.felt_to_bytes(
+                byte_array_len, 0, element_len_bytes
+            );
+            assert [rlp + rlp_len] = 0xb7 + element_len_bytes_len;
+            Helpers.fill_array(element_len_bytes_len, element_len_bytes, rlp + rlp_len + 1);
+
+            Helpers.fill_array(
+                byte_array_len, byte_array, rlp + rlp_len + 1 + element_len_bytes_len
+            );
+
+            return (rlp_len + element_len_bytes_len + byte_array_len + 1,);
         }
     }
 }

--- a/src/utils/rlp.cairo
+++ b/src/utils/rlp.cairo
@@ -168,15 +168,10 @@ namespace RLP {
 
             let (item_high, item_low) = split_felt(item);
             let (item_bytes_len) = Helpers.uint256_to_bytes_no_padding(
-                Uint256(low=item_low, high=item_high),
-                0,
-                reversed_item_bytes,
-                item_bytes,
+                Uint256(low=item_low, high=item_high), 0, reversed_item_bytes, item_bytes
             );
 
-            let (updated_rlp_len) = encode_byte_array(
-                item_bytes_len, item_bytes, rlp_len, rlp
-            );
+            let (updated_rlp_len) = encode_byte_array(item_bytes_len, item_bytes, rlp_len, rlp);
             return (updated_rlp_len,);
         }
     }
@@ -210,15 +205,11 @@ namespace RLP {
             // then the element bytes (phew)
             let (local item_len_bytes: felt*) = alloc();
             // note the subtle shift of terms: we are taking the value of the length of bytes of the item and converting it to bytes!
-            let (item_len_bytes_len) = Helpers.felt_to_bytes(
-                byte_array_len, 0, item_len_bytes
-            );
+            let (item_len_bytes_len) = Helpers.felt_to_bytes(byte_array_len, 0, item_len_bytes);
             assert [rlp + rlp_len] = 0xb7 + item_len_bytes_len;
             Helpers.fill_array(item_len_bytes_len, item_len_bytes, rlp + rlp_len + 1);
 
-            Helpers.fill_array(
-                byte_array_len, byte_array, rlp + rlp_len + 1 + item_len_bytes_len
-            );
+            Helpers.fill_array(byte_array_len, byte_array, rlp + rlp_len + 1 + item_len_bytes_len);
 
             return (rlp_len + item_len_bytes_len + byte_array_len + 1,);
         }

--- a/tests/integration/helpers/helpers.py
+++ b/tests/integration/helpers/helpers.py
@@ -2,9 +2,10 @@ import random
 from textwrap import wrap
 from typing import Tuple
 
+import rlp
 from eth_abi import encode_abi
 from eth_keys import keys
-from eth_utils import decode_hex, keccak, to_checksum_address
+from eth_utils import decode_hex, keccak, to_bytes, to_checksum_address
 
 from tests.integration.helpers.constants import CHAIN_ID
 
@@ -69,6 +70,15 @@ def get_domain_separator(name: str, token_address: str) -> bytes:
                 token_address,
             ],
         )
+    )
+
+
+def get_create_address(sender_address: str, salt: int) -> str:
+    """
+    See [CREATE](https://www.evm.codes/#f0)
+    """
+    return to_checksum_address(
+        keccak(rlp.encode([decode_hex(sender_address), to_bytes(salt)]))[-20:]
     )
 
 

--- a/tests/unit/src/kakarot/instructions/test_system_operations.cairo
+++ b/tests/unit/src/kakarot/instructions/test_system_operations.cairo
@@ -401,7 +401,13 @@ func test__exec_delegatecall__should_return_a_new_context_based_on_calling_ctx_s
 @external
 func test__exec_create__should_return_a_new_context_with_bytecode_from_memory_at_expected_address{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}(evm_contract_class_hash_: felt, registry_address_: felt, evm_caller_address: felt, salt: felt, expected_create_address: felt ) {
+}(
+    evm_contract_class_hash_: felt,
+    registry_address_: felt,
+    evm_caller_address: felt,
+    salt: felt,
+    expected_create_address: felt,
+) {
     alloc_locals;
     evm_contract_class_hash.write(evm_contract_class_hash_);
     registry_address.write(registry_address_);

--- a/tests/unit/src/kakarot/instructions/test_system_operations.py
+++ b/tests/unit/src/kakarot/instructions/test_system_operations.py
@@ -7,7 +7,7 @@ from starkware.python.utils import from_bytes
 from starkware.starknet.testing.contract import StarknetContract
 from starkware.starknet.testing.starknet import Starknet
 
-from tests.integration.helpers.helpers import get_create_address, get_create2_address
+from tests.integration.helpers.helpers import get_create2_address, get_create_address
 from tests.utils.errors import kakarot_error
 from tests.utils.uint256 import int_to_uint256
 
@@ -85,7 +85,7 @@ class TestSystemOperations:
             account_registry.contract_address,
             evm_caller_address_int,
             salt,
-            from_bytes(decode_hex(expected_create_addr))            
+            from_bytes(decode_hex(expected_create_addr)),
         ).call()
 
     async def test_create2(

--- a/tests/unit/src/kakarot/instructions/test_system_operations.py
+++ b/tests/unit/src/kakarot/instructions/test_system_operations.py
@@ -71,8 +71,9 @@ class TestSystemOperations:
             contract_account_class.class_hash, account_registry.contract_address
         ).call()
 
+    @pytest.mark.parametrize("salt", [127, 256, 2**55 - 1])
     async def test_create(
-        self, system_operations, contract_account_class, account_registry
+        self, system_operations, contract_account_class, account_registry, salt
     ):
         await system_operations.test__exec_create__should_return_a_new_context_with_bytecode_from_memory_at_empty_address(
             contract_account_class.class_hash,

--- a/tests/unit/src/kakarot/instructions/test_system_operations.py
+++ b/tests/unit/src/kakarot/instructions/test_system_operations.py
@@ -7,7 +7,7 @@ from starkware.python.utils import from_bytes
 from starkware.starknet.testing.contract import StarknetContract
 from starkware.starknet.testing.starknet import Starknet
 
-from tests.integration.helpers.helpers import get_create2_address
+from tests.integration.helpers.helpers import get_create_address, get_create2_address
 from tests.utils.errors import kakarot_error
 from tests.utils.uint256 import int_to_uint256
 
@@ -75,9 +75,17 @@ class TestSystemOperations:
     async def test_create(
         self, system_operations, contract_account_class, account_registry, salt
     ):
-        await system_operations.test__exec_create__should_return_a_new_context_with_bytecode_from_memory_at_empty_address(
+        evm_caller_address_int = 15
+        evm_caller_address_bytes = evm_caller_address_int.to_bytes(20, byteorder="big")
+        evm_caller_address = to_checksum_address(evm_caller_address_bytes)
+        expected_create_addr = get_create_address(evm_caller_address, salt)
+
+        await system_operations.test__exec_create__should_return_a_new_context_with_bytecode_from_memory_at_expected_address(
             contract_account_class.class_hash,
             account_registry.contract_address,
+            evm_caller_address_int,
+            salt,
+            from_bytes(decode_hex(expected_create_addr))            
         ).call()
 
     async def test_create2(


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 1/2 day

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Create opcode uses an easter egg 🥚 to determine the evm contract mapping.

Resolves #426 

## What is the new behavior?

The create opcode uses `CreateHelper.get_create_address` which derives the address via:

```
address = keccak256(rlp([sender_address,sender_nonce]))[12:]
```


-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
