### PR TITLE
Fix caller_address uses only execute in tests

### DIFF
--- a/tests/integration/helpers/wrap_kakarot.py
+++ b/tests/integration/helpers/wrap_kakarot.py
@@ -30,7 +30,8 @@ def wrap_for_kakarot(
             abi = contract.get_function_by_name(fun).abi
             gas_limit = kwargs.pop("gas_limit", 1_000_000)
             value = kwargs.pop("value", 0)
-            caller_address = kwargs.pop("caller_address", None)
+            # 0 is the default caller_address in both call and execute
+            caller_address = kwargs.pop("caller_address", 0)
             call = kakarot.execute_at_address(
                 address=evm_contract_address,
                 value=value,
@@ -40,8 +41,8 @@ def wrap_for_kakarot(
                 ),
             )
 
-            if abi["stateMutability"] == "view" and caller_address is None:
-                res = await call.call()
+            if abi["stateMutability"] == "view":
+                res = await call.call(caller_address=caller_address)
             else:
                 res = await call.execute(caller_address=caller_address)
             if call._traced:


### PR DESCRIPTION
Time spent on this PR: 0.5

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, one cannot `call` a solidity contract with a given `caller_address` as it makes the `call` an `execute`.

## What is the new behavior?

The `kwarg` `caller_address` is used anyhow with default value the one used on the corresponding functions, ie `0`.
