### PR TITLE
fix: do uint256 comparison for condition validity in jumpi opcode

### DIFF
--- a/src/kakarot/instructions/memory_operations.cairo
+++ b/src/kakarot/instructions/memory_operations.cairo
@@ -4,9 +4,8 @@
 
 // Starkware dependencies
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
-from starkware.cairo.common.uint256 import Uint256, uint256_unsigned_div_rem
+from starkware.cairo.common.uint256 import Uint256, uint256_le, uint256_unsigned_div_rem
 from starkware.cairo.common.alloc import alloc
-from starkware.cairo.common.math_cmp import is_le
 from starkware.cairo.common.bool import FALSE
 
 from kakarot.model import model
@@ -221,7 +220,7 @@ namespace MemoryOperations {
 
         // Update pc if skip_jump is anything other then 0
 
-        let is_condition_valid: felt = is_le(1, skip_condition.low);
+        let (is_condition_valid) = uint256_le(Uint256(1,0), skip_condition);
 
         if (is_condition_valid != FALSE) {
             // Update pc counter.

--- a/src/kakarot/instructions/memory_operations.cairo
+++ b/src/kakarot/instructions/memory_operations.cairo
@@ -220,7 +220,7 @@ namespace MemoryOperations {
 
         // Update pc if skip_jump is anything other then 0
 
-        let (is_condition_valid) = uint256_le(Uint256(1,0), skip_condition);
+        let (is_condition_valid) = uint256_le(Uint256(1, 0), skip_condition);
 
         if (is_condition_valid != FALSE) {
             // Update pc counter.

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
@@ -154,7 +154,7 @@ class TestPlainOpcodes:
                     caller_address=addresses[0].starknet_address,
                 )
 
-        @pytest.mark.parametrize("address", [2**127 , 2**128])
+        @pytest.mark.parametrize("address", [2**127, 2**128])
         async def test_should_not_revert_when_address_is_not_zero(
             self, plain_opcodes, addresses, address
         ):

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
@@ -154,13 +154,15 @@ class TestPlainOpcodes:
                     caller_address=addresses[0].starknet_address,
                 )
 
-        @pytest.mark.skip("Test fails when address is 2**128 or greater")
-        @pytest.mark.parametrize("address", [2**127, 2**128])
+        @pytest.mark.parametrize("address", [2**127 , 2**128])
         async def test_should_not_revert_when_address_is_not_zero(
             self, plain_opcodes, addresses, address
         ):
+            address_bytes = address.to_bytes(20, byteorder="big")
+            address_hex = Web3.toChecksumAddress(address_bytes)
+
             await plain_opcodes.requireNotZero(
-                f"0x{address:x}",
+                address_hex,
                 caller_address=addresses[0].starknet_address,
             )
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 1.1 days

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The exec_jumpi opcode uses the low field of the popped skipped condition to do the check if it is 'anything other than zero'

https://github.com/sayajin-labs/kakarot/blob/b5423b73dc8c32ecbd6701c5a566dc3ae3fc495b/src/kakarot/instructions/memory_operations.cairo#L224
This causes the bug because for the case of the input address of 2^128, it creates a uint with a low of zero and a high of 1. The highest range of representation the low field can do is 2^128-1.

Resolves #439 

## What is the new behavior?

Now we do a uint256_le check to have consistent results with the evm.


## Other information

I made a branch that preserves the minimized changes I added to enable debugging only when the execution_at_address entry point. I generated a log file for the passing and failing case and diffed them to better understand what was going on. Might be a useful example/starting point for anyone else needing to debug integration tests: https://github.com/jobez/kakarot/tree/cool_messy_debugging
