### PR TITLE
Use /mint route to fund account in devnet

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1474,7 +1474,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9,<3.10"
-content-hash = "a27108631b48c9eccffbb07270c8d906158e3ef10bafc90962a93e25ae5b6d0a"
+content-hash = "7a2822d97e9ca62ee30bf6989d34b598105c6264076b176641510086e478ac4d"
 
 [metadata.files]
 aiohttp = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ eth-utils = "^2.1.0"
 hypothesis = "^6.65.0"
 case-converter = "^1.1.0"
 starknet-devnet = "^0.3.5"
+requests = "^2.28.2"
 
 [tool.pytest.ini_options]
 filterwarnings = [


### PR DESCRIPTION
Time spent on this PR: 0.25

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`fund_account` use default account ETH to fund given address

## What is the new behavior?

In devnet, the `/mint` route is used instead to create ETH out of nowhere

## Other information
