### PR TITLE
Add ghcr.io and image name 'devnet' to tag

### DIFF
--- a/.github/workflows/kakarot_devnet.yml
+++ b/.github/workflows/kakarot_devnet.yml
@@ -24,6 +24,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: sayajin-labs/kakarot:latest
+          tags: ghcr.io/sayajin-labs/kakarot/devnet:latest
           context: .
           file: ./docker/devnet/Dockerfile


### PR DESCRIPTION
Time spent on this PR: 0.1

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Image built in CI is not pushed to ghcr.io

## What is the new behavior?

Tag is fixed and image is pushed to ghcr.io/sayajin-labs/kakarot/devnet

## Other information
