### PR TITLE
feature: add `query_logs` method to kkrt wrapper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ codespell = "^2.2.2"
 filterwarnings = [
     "ignore:Using or importing the ABCs:DeprecationWarning",                                # from frozendict
     "ignore:lexer_state will be removed in subsequent releases. Use lexer_thread instead.", # from lark
-    'ignore:abi:DeprecationWarning',                                                        # from web3
+    "ignore:abi:DeprecationWarning",                                                        # from web3
+    "ignore::marshmallow.warnings.RemovedInMarshmallow4Warning",                            # from marshmallow
 ]
 asyncio_mode = "auto"
 markers = [

--- a/src/kakarot/execution_context.cairo
+++ b/src/kakarot/execution_context.cairo
@@ -86,7 +86,9 @@ namespace ExecutionContext {
         let (empty_create_addresses: felt*) = alloc();
 
         let (local revert_contract_state_dict_start) = default_dict_new(0);
-        tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(revert_contract_state_dict_start, revert_contract_state_dict_start);
+        tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(
+            revert_contract_state_dict_start, revert_contract_state_dict_start
+        );
 
         // Define initial program counter
         let initial_pc = 0;
@@ -125,7 +127,7 @@ namespace ExecutionContext {
             revert_contract_state=revert_contract_state,
             reverted=FALSE,
             read_only=FALSE,
-            );
+        );
         return self;
     }
 
@@ -181,7 +183,9 @@ namespace ExecutionContext {
         let (empty_events: model.Event*) = alloc();
         let (empty_create_contracts: felt*) = alloc();
         let (local revert_contract_state_dict_start) = default_dict_new(0);
-        tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(revert_contract_state_dict_start, revert_contract_state_dict_start);
+        tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(
+            revert_contract_state_dict_start, revert_contract_state_dict_start
+        );
 
         let stack: model.Stack* = Stack.init();
         let memory: model.Memory* = Memory.init();
@@ -303,7 +307,7 @@ namespace ExecutionContext {
             revert_contract_state=self.revert_contract_state,
             reverted=self.reverted,
             read_only=self.read_only,
-            );
+        );
     }
 
     // @notice Return whether the current execution context is reverted.
@@ -785,7 +789,7 @@ namespace ExecutionContext {
             revert_contract_state=self.revert_contract_state,
             reverted=self.reverted,
             read_only=self.read_only,
-            );
+        );
     }
 
     // @notice Update the array of events to emit in the case of a execution context successfully running to completion (see `LoggingHelper.finalize`).
@@ -827,7 +831,7 @@ namespace ExecutionContext {
             revert_contract_state=self.revert_contract_state,
             reverted=self.reverted,
             read_only=self.read_only,
-            );
+        );
     }
 
     // @notice Add one contract to the array of create contracts to destroy in the case of the execution context reverting.
@@ -896,7 +900,7 @@ namespace ExecutionContext {
             revert_contract_state=self.revert_contract_state,
             reverted=self.reverted,
             read_only=self.read_only,
-            );
+        );
     }
 
     // @notice Updates the dictionary that keeps track of the prior-to-first-write value of a contract storage key so it can be reverted to if the writing execution context reverts.
@@ -905,7 +909,9 @@ namespace ExecutionContext {
     func update_revert_contract_state(
         self: model.ExecutionContext*, dict_end: DictAccess*
     ) -> model.ExecutionContext* {
-        tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(self.revert_contract_state.dict_start, dict_end);
+        tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(
+            self.revert_contract_state.dict_start, dict_end
+        );
         return new model.ExecutionContext(
             call_context=self.call_context,
             program_counter=self.program_counter,

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -772,7 +772,8 @@ namespace CreateHelper {
             );
             let ctx = ExecutionContext.push_create_address(ctx, starknet_contract_address);
             let (local revert_contract_state_dict_start) = default_dict_new(0);
-            tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(revert_contract_state_dict_start, revert_contract_state_dict_start);
+            tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(
+                revert_contract_state_dict_start, revert_contract_state_dict_start);
             tempvar sub_ctx = new model.ExecutionContext(
                 call_context=call_context,
                 program_counter=0,
@@ -815,7 +816,8 @@ namespace CreateHelper {
             );
             let ctx = ExecutionContext.push_create_address(ctx, starknet_contract_address);
             let (local revert_contract_state_dict_start) = default_dict_new(0);
-            tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(revert_contract_state_dict_start, revert_contract_state_dict_start);
+            tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(
+                revert_contract_state_dict_start, revert_contract_state_dict_start);
             tempvar sub_ctx = new model.ExecutionContext(
                 call_context=call_context,
                 program_counter=0,
@@ -860,7 +862,9 @@ namespace CreateHelper {
         let is_reverted = ExecutionContext.is_reverted(ctx);
 
         if (is_reverted != 0) {
-            local ctx: model.ExecutionContext* = ExecutionContext.update_sub_context(self=ctx.calling_context, sub_context=ctx);
+            local ctx: model.ExecutionContext* = ExecutionContext.update_sub_context(
+                self=ctx.calling_context, sub_context=ctx
+            );
             // In the case of a reverted create context, the gas of the reverted context should be rolled back and not consumed
 
             // Append contracts to selfdestruct to the calling_context
@@ -888,7 +892,9 @@ namespace CreateHelper {
             let dynamic_gas = ctx.gas_used + 200 * ctx.return_data_len * Constants.BYTES_PER_FELT;
             let ctx = ExecutionContext.increment_gas_used(self=ctx, inc_value=dynamic_gas);
 
-            local ctx: model.ExecutionContext* = ExecutionContext.update_sub_context(self=ctx.calling_context, sub_context=ctx);
+            local ctx: model.ExecutionContext* = ExecutionContext.update_sub_context(
+                self=ctx.calling_context, sub_context=ctx
+            );
             let ctx = ExecutionContext.increment_gas_used(ctx, ctx.sub_context.gas_used);
 
             // Append contracts to selfdestruct to the calling_context
@@ -927,7 +933,9 @@ namespace SelfDestructHelper {
         let (empty_create_addresses: felt*) = alloc();
         let (empty_events: model.Event*) = alloc();
         let (revert_contract_state_dict_start) = default_dict_new(0);
-        tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(revert_contract_state_dict_start, revert_contract_state_dict_start);
+        tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(
+            revert_contract_state_dict_start, revert_contract_state_dict_start
+        );
 
         return new model.ExecutionContext(
             call_context=ctx.call_context,

--- a/src/kakarot/precompiles/precompiles.cairo
+++ b/src/kakarot/precompiles/precompiles.cairo
@@ -59,7 +59,9 @@ namespace Precompiles {
         memcpy(return_data, output, output_len);
 
         let (local revert_contract_state_dict_start) = default_dict_new(0);
-        tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(revert_contract_state_dict_start, revert_contract_state_dict_start);
+        tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(
+            revert_contract_state_dict_start, revert_contract_state_dict_start
+        );
         // Build returned execution context
         local sub_ctx: model.ExecutionContext* = new model.ExecutionContext(
             call_context=cast(0, model.CallContext*),

--- a/tests/integration/helpers/wrap_kakarot.py
+++ b/tests/integration/helpers/wrap_kakarot.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import cast
+from typing import List, Optional, cast
 
 from starkware.starknet.testing.starknet import StarknetContract
 from web3 import Web3
@@ -14,12 +14,63 @@ from tests.utils.helpers import hex_string_to_bytes_array
 from tests.utils.reporting import traceit
 
 
+def get_matching_logs_for_event(codec, event_abi, log_receipts) -> List[dict]:
+    logs = []
+    for log_receipt in log_receipts:
+        try:
+            event_data = get_event_data(codec, event_abi, log_receipt)
+            logs += [event_data.args]
+        except:
+            pass
+    return logs
+
+
 def wrap_for_kakarot(
     contract: Contract, kakarot: StarknetContract, evm_contract_address: int
 ):
     """
     Wrap a web3.contract to use kakarot as backend.
     """
+
+    # query_logs enables three cases
+    # no kwargs means you get all of the log_receipts
+    # when a contract is supplied, you get all the log entries that correspond to the contract's event abi
+    # when a contract is supplied with an event name, you get the log entries that match that event name
+    def query_logs(self_contract, *args, **kwargs):
+        logs = []
+        codec = Web3().codec
+        contract = kwargs.pop("contract", None)
+        event_name = kwargs.pop("event_name", None)
+        log_receipts = self_contract.raw_log_receipts
+
+        # Case 1: No contract key supplied
+        # return all raw logs
+        if contract is None:
+            return log_receipts
+
+        # Case 2: Contract key supplied, no event name
+        # user gets all the events associated with a contract
+        set(event_abi["name"] for event_abi in contract.events._events)
+        if event_name is None:
+            for event_abi in contract.events._events:
+                logs += get_matching_logs_for_event(codec, event_abi, log_receipts)
+            return logs
+
+        # Case 3: Contract key and event name supplied
+        event_abi = next(
+            (
+                event_abi
+                for event_abi in contract.events._events
+                if event_abi["name"] == event_name
+            ),
+            None,
+        )
+        if event_abi is None:
+            raise ValueError(
+                f"Cannot find event ABI for {event_name} in contract {contract._contract_name}"
+            )
+        logs += get_matching_logs_for_event(codec, event_abi, log_receipts)
+        return logs
 
     def wrap_zk_evm(fun: str, evm_contract_address: int):
         """
@@ -93,14 +144,10 @@ def wrap_for_kakarot(
                     continue
 
             for event_abi in contract.events._events:
-                logs = []
-                for log_receipt in log_receipts:
-                    try:
-                        logs += [get_event_data(codec, event_abi, log_receipt).args]
-                    except:
-                        pass
+                logs = get_matching_logs_for_event(codec, event_abi, log_receipts)
                 setattr(contract.events, event_abi["name"], logs)
 
+            setattr(contract, "raw_log_receipts", log_receipts)
             setattr(contract, "tx", res)
 
             return result
@@ -113,6 +160,7 @@ def wrap_for_kakarot(
             fun,
             classmethod(wrap_zk_evm(fun, evm_contract_address)),
         )
+    setattr(contract, "query_logs", classmethod(query_logs))
     return contract
 
 
@@ -123,10 +171,14 @@ def wrap_for_kakarot(
 # Example: get_contract("Solmate", "ERC721") will load the ERC721.sol file in the tests/integration/solidity_contracts/Solmate folder
 # Example: get_contract("StarkEx", "StarkExchange") will load the StarkExchange.sol file in the tests/integration/solidity_contracts/StarkEx/starkex folder
 #
-def get_contract(contract_app: str, contract_name: str) -> Contract:
+def get_contract(
+    contract_app: str, contract_name: str, subcontract_name: Optional[str] = None
+) -> Contract:
     """
     Return a web3.contract instance based on the corresponding solidity files
     defined in tests/integration/solidity_files.
+
+    If subcontract_name is provided, use it instead of contract_name for the result of compilation_outputs.
     """
     solidity_contracts_dir = Path("tests") / "integration" / "solidity_contracts"
     target_solidity_file_path = list(
@@ -134,6 +186,9 @@ def get_contract(contract_app: str, contract_name: str) -> Contract:
     )
     if len(target_solidity_file_path) != 1:
         raise ValueError(f"Cannot locate a unique {contract_name} in {contract_app}")
+
+    if subcontract_name:
+        contract_name = subcontract_name
 
     compilation_outputs = [
         json.load(open(file))

--- a/tests/integration/helpers/wrap_kakarot.py
+++ b/tests/integration/helpers/wrap_kakarot.py
@@ -50,7 +50,6 @@ def wrap_for_kakarot(
 
         # Case 2: Contract key supplied, no event name
         # user gets all the events associated with a contract
-        set(event_abi["name"] for event_abi in contract.events._events)
         if event_name is None:
             for event_abi in contract.events._events:
                 logs += get_matching_logs_for_event(codec, event_abi, log_receipts)
@@ -172,13 +171,13 @@ def wrap_for_kakarot(
 # Example: get_contract("StarkEx", "StarkExchange") will load the StarkExchange.sol file in the tests/integration/solidity_contracts/StarkEx/starkex folder
 #
 def get_contract(
-    contract_app: str, contract_name: str, subcontract_name: Optional[str] = None
+    contract_app: str, contract_name: str, contract_alias: Optional[str] = None
 ) -> Contract:
     """
     Return a web3.contract instance based on the corresponding solidity files
     defined in tests/integration/solidity_files.
 
-    If subcontract_name is provided, use it instead of contract_name for the result of compilation_outputs.
+    If contract_alias is provided, use it instead of contract_name for the result of compilation_outputs.
     """
     solidity_contracts_dir = Path("tests") / "integration" / "solidity_contracts"
     target_solidity_file_path = list(
@@ -187,8 +186,8 @@ def get_contract(
     if len(target_solidity_file_path) != 1:
         raise ValueError(f"Cannot locate a unique {contract_name} in {contract_app}")
 
-    if subcontract_name:
-        contract_name = subcontract_name
+    if contract_alias:
+        contract_name = contract_alias
 
     compilation_outputs = [
         json.load(open(file))

--- a/tests/integration/solidity_contracts/PlainOpcodes/conftest.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/conftest.py
@@ -3,9 +3,7 @@ import pytest_asyncio
 
 @pytest_asyncio.fixture(scope="module")
 async def counter(deploy_solidity_contract, owner):
-    return await deploy_solidity_contract(
-        "PlainOpcodes", "Counter", caller_eoa=owner
-    )
+    return await deploy_solidity_contract("PlainOpcodes", "Counter", caller_eoa=owner)
 
 
 @pytest_asyncio.fixture(scope="module")

--- a/tests/unit/helpers/helpers.cairo
+++ b/tests/unit/helpers/helpers.cairo
@@ -53,7 +53,7 @@ namespace TestHelpers {
         assert [calldata] = '';
         local call_context: model.CallContext* = new model.CallContext(
             bytecode=bytecode, bytecode_len=bytecode_len, calldata=calldata, calldata_len=1, value=0
-            );
+        );
         let self: model.ExecutionContext* = ExecutionContext.init(call_context);
 
         return new model.ExecutionContext(
@@ -80,7 +80,7 @@ namespace TestHelpers {
             revert_contract_state=self.revert_contract_state,
             reverted=self.reverted,
             read_only=self.read_only,
-            );
+        );
     }
 
     func init_context_with_stack{
@@ -111,7 +111,9 @@ namespace TestHelpers {
         let self: model.ExecutionContext* = init_context_with_stack(bytecode_len, bytecode, stack);
 
         let (local revert_contract_state_dict_start) = default_dict_new(0);
-        tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(revert_contract_state_dict_start, revert_contract_state_dict_start);
+        tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(
+            revert_contract_state_dict_start, revert_contract_state_dict_start
+        );
 
         return new model.ExecutionContext(
             call_context=self.call_context,

--- a/tests/unit/src/kakarot/accounts/eoa/test_library.py
+++ b/tests/unit/src/kakarot/accounts/eoa/test_library.py
@@ -60,7 +60,9 @@ class TestLibrary:
         expected_balances = Counter()
 
         # Storing initial balance, as eth storage persists across tests.
-        initial_balance = (await eth.balanceOf(mock_externally_owned_account.contract_address).call()).result.balance.low
+        initial_balance = (
+            await eth.balanceOf(mock_externally_owned_account.contract_address).call()
+        ).result.balance.low
 
         # Mint tokens to the EOA
         await eth.mint(

--- a/tests/unit/src/kakarot/instructions/test_environmental_information.cairo
+++ b/tests/unit/src/kakarot/instructions/test_environmental_information.cairo
@@ -89,7 +89,9 @@ func init_context{
     let sub_context = ExecutionContext.init_empty();
 
     let (local revert_contract_state_dict_start) = default_dict_new(0);
-    tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(revert_contract_state_dict_start, revert_contract_state_dict_start);
+    tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(
+        revert_contract_state_dict_start, revert_contract_state_dict_start
+    );
 
     local ctx: model.ExecutionContext* = new model.ExecutionContext(
         call_context=call_context,

--- a/tests/unit/src/kakarot/precompiles/test_modexp.py
+++ b/tests/unit/src/kakarot/precompiles/test_modexp.py
@@ -16,7 +16,7 @@ async def modexp(starknet: Starknet):
 
 
 @pytest.mark.asyncio
-@pytest.mark.MODEXP
+@pytest.mark.MOD_EXP
 class TestModExp:
     async def test_modexp(self, modexp):
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 0.5

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Revert tests were unable to assert that a given event emitted from a subcontext was not emitted.

Resolves #<Issue number>

## What is the new behavior?

The kakarot wrapper now has a `query_logs` method that, when called with 
- no args -> returns the raw logs of transaction.
- contract key -> returns all the events in logs that match the event abi of the contract
-  contract key  x event name -> returns the events that match the particular event name

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
