### PR TITLE
Disable RPC json validation in devnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,4 +88,4 @@ build-sol:
 	forge build --names --force
 
 run:
-	poetry run starknet-devnet --lite-mode --seed 0 --dump-on exit --dump-path devnet.pkl
+	poetry run starknet-devnet --lite-mode --seed 0 --dump-on exit --dump-path devnet.pkl --disable-rpc-request-validation

--- a/docker/devnet/Dockerfile
+++ b/docker/devnet/Dockerfile
@@ -13,4 +13,4 @@ RUN poetry run python ./docker/devnet/run_and_deploy.py
 FROM shardlabs/starknet-devnet:0.4.6
 
 COPY --from=builder /kakarot/devnet.pkl devnet.pkl
-ENTRYPOINT ["starknet-devnet", "--host", "0.0.0.0", "--port", "5050", "--load-path", "devnet.pkl"]
+ENTRYPOINT ["starknet-devnet", "--host", "0.0.0.0", "--port", "5050", "--load-path", "devnet.pkl", "--disable-rpc-request-validation"]


### PR DESCRIPTION
Time spent on this PR: 0.5

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The JSON RPC spec does not allow for address missing the leading 0 in hex string

## What is the new behavior?

Devnet is started with the `--disable-rpc-request-validation` flag to skip this validation?

## Other information

See corresponding discussion in https://github.com/Shard-Labs/starknet-devnet/issues/401
