### PR TITLE
Use rust VM for devnet

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -8,7 +8,10 @@ TESTNET_PRIVATE_KEY=
 TESTNET2_ACCOUNT_ADDRESS=
 TESTNET2_PRIVATE_KEY=
 
-# These will be used if above variables are not set
+DEVNET_ACCOUNT_ADDRESS=0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a
+DEVNET_PRIVATE_KEY=0xe3e70682c2094cac629f6fbed82c07cd
+
+# These will be used if above variables are not set for the given network
 ACCOUNT_ADDRESS=
 PRIVATE_KEY=
 

--- a/docker/devnet/Dockerfile
+++ b/docker/devnet/Dockerfile
@@ -1,4 +1,5 @@
 FROM shardlabs/starknet-devnet:0.4.6
 
 COPY ./deployments/devnet/devnet.pkl devnet.pkl
+ENV STARKNET_DEVNET_CAIRO_VM=rust
 ENTRYPOINT ["starknet-devnet", "--host", "0.0.0.0", "--port", "5050", "--load-path", "devnet.pkl", "--disable-rpc-request-validation"]

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -119,22 +119,6 @@ async def get_account(
     address=None,
     private_key=None,
 ) -> AccountClient:
-    if NETWORK == "devnet":
-        # Hard-coded values when running starknet-devnet with seed = 0
-        return AccountClient(
-            address="0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a",
-            client=GATEWAY_CLIENT,
-            supported_tx_version=1,
-            chain=CHAIN_ID,
-            key_pair=KeyPair(
-                private_key=int("0xe3e70682c2094cac629f6fbed82c07cd", 16),
-                public_key=int(
-                    "0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9",
-                    16,
-                ),
-            ),
-        )
-
     address = int(address or ACCOUNT_ADDRESS, 16)
     key_pair = KeyPair.from_private_key(int(private_key or PRIVATE_KEY, 16))
     call = Call(


### PR DESCRIPTION
Time spent on this PR: 0.5

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The devnet uses the python VM, which is less performant and unexpectedly crashes when deploying an ERC20.

## What is the new behavior?

Use the rust VM instead. As a matter of fact, the ERC20 deployment failing after ~1m20s is now passing in ~25s on my laptop

## Other information

Updated the .env variables to simplify the get_account method