### PR TITLE
gasprice should return txn constant

### DIFF
--- a/src/kakarot/instructions/environmental_information.cairo
+++ b/src/kakarot/instructions/environmental_information.cairo
@@ -420,10 +420,10 @@ namespace EnvironmentalInformation {
         alloc_locals;
 
         // Get the gasprice.
-        let cost_felt = ExecutionContext.compute_intrinsic_gas_cost(ctx);
-        let cost_uint256 = Helpers.to_uint256(cost_felt);
+        let gas_price_felt = ctx.gas_price;
+        let gas_price_uint256 = Helpers.to_uint256(gas_price_felt);
 
-        let stack: model.Stack* = Stack.push(self=ctx.stack, element=cost_uint256);
+        let stack: model.Stack* = Stack.push(self=ctx.stack, element=gas_price_uint256);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -395,10 +395,10 @@ namespace SystemOperations {
         );
         let sender = ctx.starknet_contract_address;
         let (success) = IEth.transferFrom(
-            contract_address=native_token_address_, 
+            contract_address=native_token_address_,
             sender=sender,
-            recipient=address_felt, 
-            amount=balance
+            recipient=address_felt,
+            amount=balance,
         );
         with_attr error_message(
                 "Kakarot: 0xFF: failed to transfer token from {sender} to {address_felt}") {

--- a/tests/unit/src/kakarot/instructions/test_environmental_information.cairo
+++ b/tests/unit/src/kakarot/instructions/test_environmental_information.cairo
@@ -284,26 +284,19 @@ func test__exec_extcodecopy__should_handle_address_with_no_code{
 @external
 func test__exec_gasprice{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}(zeroes: felt, nonzeroes: felt, calldata_len: felt, calldata: felt*) {
+}() {
     // Given
     alloc_locals;
     let (bytecode) = alloc();
     assert [bytecode] = 00;
     tempvar bytecode_len = 1;
-
-    let dynamic_gas_price_felt = zeroes * 4 + nonzeroes * 16;
-    let expected_gas_price_felt = dynamic_gas_price_felt + Constants.TRANSACTION_INTRINSIC_GAS_COST;
-    let expected_gas_price_uint256 = Helpers.to_uint256(expected_gas_price_felt);
-
-    // When
-    local call_context: model.CallContext* = new model.CallContext(
-        bytecode=bytecode,
-        bytecode_len=bytecode_len,
-        calldata=calldata,
-        calldata_len=calldata_len,
-        value=0,
+    let stack = Stack.init();
+    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(
+        bytecode_len, bytecode, stack
     );
-    let ctx: model.ExecutionContext* = ExecutionContext.init(call_context);
+
+    let expected_gas_price_uint256 = Helpers.to_uint256(ctx.gas_price);
+
     let result = EnvironmentalInformation.exec_gasprice(ctx);
     let (stack, gasprice) = Stack.peek(result.stack, 0);
 

--- a/tests/unit/src/kakarot/instructions/test_environmental_information.py
+++ b/tests/unit/src/kakarot/instructions/test_environmental_information.py
@@ -88,20 +88,9 @@ class TestEnvironmentalInformation:
 
         assert memory_result == expected
 
-    @pytest.mark.parametrize(
-        "zeroes,nonzeroes",
-        [(4, 0), (0, 4), (4, 4)],
-        ids=["only_zeroes", "only_nonzeroes", "both_zeroes_and_nonzeroes"],
-    )
-    async def test_gasprice(self, environmental_information, zeroes, nonzeroes):
-        random.seed(0)
-        random_nonzeroes = [random.randint(1, 255) for _ in range(nonzeroes)]
-        calldata = [0] * zeroes + random_nonzeroes
-        random.shuffle(calldata)
+    async def test_gasprice(self, environmental_information):
 
-        await environmental_information.test__exec_gasprice(
-            zeroes=zeroes, nonzeroes=nonzeroes, calldata=calldata
-        ).call()
+        await environmental_information.test__exec_gasprice().call()
 
     @pytest.mark.skip("skipped because not handled currently")
     async def test_extcodehash__should_handle_invalid_address(

--- a/tests/unit/src/kakarot/instructions/test_system_operations.cairo
+++ b/tests/unit/src/kakarot/instructions/test_system_operations.cairo
@@ -266,10 +266,12 @@ func test__exec_call__should_transfer_value{
     let (callee_starknet_contract_address) = Accounts.create(
         contract_account_class_hash_, callee_evm_contract_address
     );
-    
+
     // Get the balance of caller pre-call
     let (native_token_address_) = native_token_address.read();
-    let (caller_pre_balance) = IEth.balanceOf(contract_address=native_token_address_, account=caller_starknet_contract_address);
+    let (caller_pre_balance) = IEth.balanceOf(
+        contract_address=native_token_address_, account=caller_starknet_contract_address
+    );
 
     // Fill the stack with input data
     let stack: model.Stack* = Stack.init();
@@ -304,13 +306,17 @@ func test__exec_call__should_transfer_value{
 
     // Then
     // get balances of caller and callee post-call
-    let (callee_balance) = IEth.balanceOf(contract_address=native_token_address_, account=callee_starknet_contract_address);
-    let (caller_post_balance) = IEth.balanceOf(contract_address=native_token_address_, account=caller_starknet_contract_address);
+    let (callee_balance) = IEth.balanceOf(
+        contract_address=native_token_address_, account=callee_starknet_contract_address
+    );
+    let (caller_post_balance) = IEth.balanceOf(
+        contract_address=native_token_address_, account=caller_starknet_contract_address
+    );
     let (caller_diff_balance) = uint256_sub(caller_pre_balance, caller_post_balance);
 
     assert callee_balance = Uint256(2, 0);
     assert caller_diff_balance = Uint256(2, 0);
-    return();
+    return ();
 }
 
 @external
@@ -326,9 +332,7 @@ func test__exec_callcode__should_return_a_new_context_based_on_calling_ctx_stack
         contract_account_class_hash_, caller_evm_contract_address
     );
     let (callee_evm_contract_address) = CreateHelper.get_create_address(1, 0);
-    let (_) = Accounts.create(
-        contract_account_class_hash_, callee_evm_contract_address
-    );
+    let (_) = Accounts.create(contract_account_class_hash_, callee_evm_contract_address);
 
     // Fill the stack with input data
     let stack: model.Stack* = Stack.init();
@@ -415,10 +419,12 @@ func test__exec_callcode__should_transfer_value{
     let (callee_starknet_contract_address) = Accounts.create(
         contract_account_class_hash_, callee_evm_contract_address
     );
-    
+
     // Get the balance of caller pre-call
     let (native_token_address_) = native_token_address.read();
-    let (caller_pre_balance) = IEth.balanceOf(contract_address=native_token_address_, account=caller_starknet_contract_address);
+    let (caller_pre_balance) = IEth.balanceOf(
+        contract_address=native_token_address_, account=caller_starknet_contract_address
+    );
 
     // Fill the stack with input data
     let stack: model.Stack* = Stack.init();
@@ -453,13 +459,17 @@ func test__exec_callcode__should_transfer_value{
 
     // Then
     // get balances of caller and callee post-call
-    let (callee_balance) = IEth.balanceOf(contract_address=native_token_address_, account=callee_starknet_contract_address);
-    let (caller_post_balance) = IEth.balanceOf(contract_address=native_token_address_, account=caller_starknet_contract_address);
+    let (callee_balance) = IEth.balanceOf(
+        contract_address=native_token_address_, account=callee_starknet_contract_address
+    );
+    let (caller_post_balance) = IEth.balanceOf(
+        contract_address=native_token_address_, account=caller_starknet_contract_address
+    );
     let (caller_diff_balance) = uint256_sub(caller_pre_balance, caller_post_balance);
 
     assert callee_balance = Uint256(2, 0);
     assert caller_diff_balance = Uint256(2, 0);
-    return();
+    return ();
 }
 
 @external


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: .1

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Gasprice was returning a nonconstant value that was dependent on execution.

Resolves #<Issue number>

## What is the new behavior?

Gasprice returns the amount of ether that the sender is willing to pay per unit of gas to execute the transaction.


## Other information

I believe gasPrice is relayed from the rpc to the execution system, but currently only `gas_limit` is parameterized at the entry point of `execute_at_address`, so pragmaticly this opcode is always returning zero.