### PR TITLE
Fix compute_half_uint256 overhead

### DIFF
--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -156,8 +156,8 @@ namespace Helpers {
     }
 
     // @notice: This function takes a number in base b and returns felt
-    // @param digits: array of digets
     // @param digits_len: length od digets
+    // @param digits: array of digets
     // @param base: base of the number system
     // @return res: decimal representation of digits
     // @return res: base in pover of digits_len
@@ -172,12 +172,12 @@ namespace Helpers {
             assert_lt([digits], base);
         }
 
-        let (res, weight) = compose_felt(digits + 1, digits_len - 1, base);
+        let (res, weight) = compose_felt(digits_len - 1, digits + 1, base);
         return ([digits] * weight + res, weight * base);
     }
 
     func compute_half_uint256{range_check_ptr}(bytes: felt*, bytes_len: felt) -> (res: felt) {
-        let (res, _) = compose_felt(bytes, bytes_len, 256);
+        let (res, _) = compose_felt(bytes_len, bytes, 256);
         return (res,);
     }
 

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -155,11 +155,13 @@ namespace Helpers {
         return (res=quotient);
     }
 
-    // @notice: This function returns a numbers in the base b system
+    // @notice: This function takes a number in base b and returns felt
     // @param digits: array of digets
     // @param digits_len: length od digets
+    // @param base: base of the number system
     // @return res: decimal representation of digits
-    func compose_felt{range_check_ptr}(digits: felt*, digits_len: felt, base: felt) -> (
+    // @return res: base in pover of digits_len
+    func compose_felt{range_check_ptr}(digits_len: felt, digits: felt*, base: felt) -> (
         res: felt, weight: felt
     ) {
         if (digits_len == 0) {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Fixed overhead of `compute_half_uint256` since now power of base will be computed recursively.

<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 0.1

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Current behaviour requires more computation ergo gas but basically does the same job.

Resolves #<Issue number>

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixed perfomance of `compute_half_uint256`
- Added `compose_felt` function which is an opposite of `split_int`
- Cleaned `bytes32_to_uint256` + added range check

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
