### PR TITLE
fix(fund_address): fix address to be hex when network is devnet

### DIFF
--- a/scripts/utils/starknet.py
+++ b/scripts/utils/starknet.py
@@ -202,7 +202,7 @@ async def fund_address(address: Union[int, str], amount: float):
     amount = amount * 1e18
     if NETWORK == "devnet":
         response = requests.post(
-            f"{GATEWAY_CLIENT.net}/mint", json={"address": address, "amount": amount}
+            f"{GATEWAY_CLIENT.net}/mint", json={"address": hex(address), "amount": amount}
         )
         if response.status_code != 200:
             logger.error(f"Cannot mint token to {address}: {response.text}")


### PR DESCRIPTION
Fix the address to be hex inside the fund_address function when the input is of type int and the network is devnet.



## Pull request type: fix

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Upon investigating #568 , I found that the following function calls are involved:
- deploy_and_fund_evm_address 
- fund_address

When we investigate fund_address, the following code snippet is where the error comes from:

```python
 address = int(address, 16) if isinstance(address, str) else address
    amount = amount * 1e18
    if NETWORK == "devnet":
        response = requests.post(
            f"{GATEWAY_CLIENT.net}/mint", json={"address": address, "amount": amount}
        )
        if response.status_code != 200:
            logger.error(f"Cannot mint token to {address}: {response.text}")
        logger.info(f"{amount / 1e18} ETH minted to {address}")
```

the address is expected to be a hex string, and since it is not we get the error described in #568.

Resolves <https://github.com/sayajin-labs/kakarot/issues/568>

## What is the new behavior?

In the new behavior, if the type is *int*, then we call **hex()** to it, to convert it into a hex string.
